### PR TITLE
fix: 仕様書との差分 10件を修正

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,6 +11,7 @@ export interface SelectorConfig {
 export interface ProfileConfig {
   statsDataId: string;
   selectors?: SelectorConfig;
+  notes?: string;
 }
 
 export interface EstatConfig {
@@ -44,7 +45,8 @@ export async function writeInitFiles(): Promise<string[]> {
       defaultProfile: "population",
       profiles: {
         population: {
-          statsDataId: "REPLACE_WITH_STATS_DATA_ID"
+          statsDataId: "REPLACE_WITH_STATS_DATA_ID",
+          notes: "市区町村別・年齢階級（総数/0-14）を含む統計表を指定する"
         }
       }
     };
@@ -70,10 +72,15 @@ export function resolveStatsDataId(args: {
 }): { statsDataId: string; selectors?: SelectorConfig; source: string } {
   if (args.explicitStatsDataId) {
     if (args.explicitStatsDataId.includes("REPLACE_WITH")) {
-      throw new CliError("statsDataId がプレースホルダのままです", [
-        "実在する statsDataId を --statsDataId で指定してください。",
-        "候補探索: estat-report search --keyword \"人口\""
-      ]);
+      throw new CliError(
+        "statsDataId がプレースホルダのままです",
+        [
+          "実在する statsDataId を --statsDataId で指定してください。",
+          "候補探索: estat-report search --keyword \"人口\""
+        ],
+        undefined,
+        2
+      );
     }
     return {
       statsDataId: args.explicitStatsDataId,
@@ -85,16 +92,26 @@ export function resolveStatsDataId(args: {
   if (profileName) {
     const profile = args.config.profiles?.[profileName];
     if (!profile?.statsDataId) {
-      throw new CliError(`profile '${profileName}' が見つからないか statsDataId が未設定です`, [
-        "estat.config.json の profiles を確認してください。",
-        "または --statsDataId <ID> を直接指定してください。"
-      ]);
+      throw new CliError(
+        `profile '${profileName}' が見つからないか statsDataId が未設定です`,
+        [
+          "estat.config.json の profiles を確認してください。",
+          "または --statsDataId <ID> を直接指定してください。"
+        ],
+        undefined,
+        2
+      );
     }
     if (profile.statsDataId.includes("REPLACE_WITH")) {
-      throw new CliError(`profile '${profileName}' の statsDataId がプレースホルダです`, [
-        "estat.config.json で実在する statsDataId に置き換えてください。",
-        "候補探索: estat-report search --keyword \"人口\""
-      ]);
+      throw new CliError(
+        `profile '${profileName}' の statsDataId がプレースホルダです`,
+        [
+          "estat.config.json で実在する statsDataId に置き換えてください。",
+          "候補探索: estat-report search --keyword \"人口\""
+        ],
+        undefined,
+        2
+      );
     }
     return {
       statsDataId: profile.statsDataId,
@@ -103,9 +120,14 @@ export function resolveStatsDataId(args: {
     };
   }
 
-  throw new CliError("statsDataId が未指定です", [
-    "--statsDataId <ID> を指定してください。",
-    "または estat-report init を実行して profile を作成し、--profile <name> を指定してください。",
-    "候補を探すには estat-report search --keyword \"人口\" を利用してください。"
-  ]);
+  throw new CliError(
+    "statsDataId が未指定です",
+    [
+      "--statsDataId <ID> を指定してください。",
+      "または estat-report init を実行して profile を作成し、--profile <name> を指定してください。",
+      "候補を探すには estat-report search --keyword \"人口\" を利用してください。"
+    ],
+    undefined,
+    2
+  );
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,12 +1,14 @@
 export class CliError extends Error {
   readonly hints: string[];
   readonly details?: string;
+  readonly exitCode: number;
 
-  constructor(message: string, hints: string[] = [], details?: string) {
+  constructor(message: string, hints: string[] = [], details?: string, exitCode = 1) {
     super(message);
     this.name = "CliError";
     this.hints = hints;
     this.details = details;
+    this.exitCode = exitCode;
   }
 }
 

--- a/src/estat/client.ts
+++ b/src/estat/client.ts
@@ -16,6 +16,27 @@ export interface GetStatsDataParams {
   [key: string]: string | number | undefined;
 }
 
+const MAX_RETRIES = 3;
+const INITIAL_DELAY_MS = 1000;
+
+function isRetryableError(error: unknown): boolean {
+  if (!axios.isAxiosError(error)) {
+    return false;
+  }
+  if (error.code === "ECONNABORTED" || error.code === "ETIMEDOUT") {
+    return true;
+  }
+  const status = error.response?.status;
+  if (status === 429 || (status !== undefined && status >= 500)) {
+    return true;
+  }
+  return false;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export class EstatApiClient {
   private readonly http: AxiosInstance;
 
@@ -27,38 +48,52 @@ export class EstatApiClient {
   }
 
   private async request(endpoint: string, params: Record<string, string | number | undefined>): Promise<any> {
-    try {
-      const response = await this.http.get(endpoint, {
-        params: {
-          appId: this.appId,
-          lang: "J",
-          ...params
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const response = await this.http.get(endpoint, {
+          params: {
+            appId: this.appId,
+            lang: "J",
+            ...params
+          }
+        });
+
+        const data = response.data;
+        const root = data?.GET_STATS_DATA ?? data?.GET_META_INFO ?? data?.GET_STATS_LIST;
+        const result = root?.RESULT;
+        const status = String(result?.STATUS ?? "0");
+        const errorMsg = textFrom(result?.ERROR_MSG);
+
+        if (status !== "0") {
+          throw new CliError(`e-Stat APIエラー(status=${status})`, errorMsg ? [errorMsg] : []);
         }
-      });
 
-      const data = response.data;
-      const root = data?.GET_STATS_DATA ?? data?.GET_META_INFO ?? data?.GET_STATS_LIST;
-      const result = root?.RESULT;
-      const status = String(result?.STATUS ?? "0");
-      const errorMsg = textFrom(result?.ERROR_MSG);
+        return data;
+      } catch (error) {
+        if (error instanceof CliError) {
+          throw error;
+        }
+        lastError = error;
 
-      if (status !== "0") {
-        throw new CliError(`e-Stat APIエラー(status=${status})`, errorMsg ? [errorMsg] : []);
-      }
+        if (!isRetryableError(error) || attempt >= MAX_RETRIES - 1) {
+          break;
+        }
 
-      return data;
-    } catch (error) {
-      if (error instanceof CliError) {
-        throw error;
+        const delayMs = INITIAL_DELAY_MS * Math.pow(2, attempt);
+        await sleep(delayMs);
       }
-      if (axios.isAxiosError(error)) {
-        throw new CliError("e-Stat APIへの通信に失敗しました", [
-          `HTTPエラー: ${error.message}`,
-          "ESTAT_APP_ID が有効か確認してください。"
-        ]);
-      }
-      throw error;
     }
+
+    if (axios.isAxiosError(lastError)) {
+      throw new CliError("e-Stat APIへの通信に失敗しました", [
+        `HTTPエラー: ${lastError.message}`,
+        `${MAX_RETRIES}回リトライしましたが成功しませんでした。`,
+        "ESTAT_APP_ID が有効か確認してください。"
+      ]);
+    }
+    throw lastError;
   }
 
   async getStatsList(keyword: string, limit = 20): Promise<StatsListItem[]> {

--- a/src/estat/report-data.ts
+++ b/src/estat/report-data.ts
@@ -25,16 +25,20 @@ export interface BuildReportInput {
   metaInfo: any;
 }
 
+export interface ReportRow {
+  cityInput: string;
+  cityResolved: string;
+  areaCode: string;
+  total: number;
+  kids: number;
+  ratio: number;
+  totalRank: number;
+  ratioRank: number;
+}
+
 export interface BuildReportResult {
   outPath: string;
-  rows: Array<{
-    cityInput: string;
-    cityResolved: string;
-    areaCode: string;
-    total: number;
-    kids: number;
-    ratio: number;
-  }>;
+  rows: ReportRow[];
   timeLabel: string;
   totalLabel: string;
   kidsLabel: string;
@@ -96,7 +100,7 @@ export async function buildReportData(input: BuildReportInput): Promise<BuildRep
     })
   ]);
 
-  const rows = cities.map((city) => {
+  const baseRows = cities.map((city) => {
     const total = totalMap.get(city.code);
     const kids = kidsMap.get(city.code);
 
@@ -117,6 +121,15 @@ export async function buildReportData(input: BuildReportInput): Promise<BuildRep
       ratio: total > 0 ? (kids / total) * 100 : 0
     };
   });
+
+  const totalSorted = [...baseRows].sort((a, b) => b.total - a.total);
+  const ratioSorted = [...baseRows].sort((a, b) => b.ratio - a.ratio);
+
+  const rows: ReportRow[] = baseRows.map((row) => ({
+    ...row,
+    totalRank: totalSorted.findIndex((r) => r.areaCode === row.areaCode) + 1,
+    ratioRank: ratioSorted.findIndex((r) => r.areaCode === row.areaCode) + 1
+  }));
 
   return {
     outPath: resolveOutPath(input.outPath),

--- a/src/report/html.ts
+++ b/src/report/html.ts
@@ -7,6 +7,8 @@ export interface ReportRow {
   total: number;
   kids: number;
   ratio: number;
+  totalRank: number;
+  ratioRank: number;
 }
 
 export interface ReportModel {
@@ -16,6 +18,7 @@ export interface ReportModel {
   timeLabel: string;
   totalLabel: string;
   kidsLabel: string;
+  classInfo: string;
   rows: ReportRow[];
 }
 
@@ -34,11 +37,15 @@ export function renderReportHtml(model: ReportModel): string {
         <td>${escapeHtml(row.cityResolved)}</td>
         <td>${escapeHtml(row.areaCode)}</td>
         <td class="num">${numberFormat(row.total)}</td>
+        <td class="num">${row.totalRank}</td>
         <td class="num">${numberFormat(row.kids)}</td>
         <td class="num">${ratioText}</td>
+        <td class="num">${row.ratioRank}</td>
       </tr>`;
     })
     .join("\n");
+
+  const citiesList = model.rows.map((r) => escapeHtml(r.cityInput)).join("、");
 
   return `<!doctype html>
 <html lang="ja">
@@ -63,15 +70,34 @@ export function renderReportHtml(model: ReportModel): string {
         background: linear-gradient(150deg, #f8fafc 0%, #eff6ff 100%);
         font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
       }
+      .cover {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        min-height: calc(100vh - 40px);
+        text-align: center;
+        page-break-after: always;
+      }
+      .cover h1 {
+        font-size: 28px;
+        color: var(--accent);
+        margin-bottom: 24px;
+      }
+      .cover .cover-meta {
+        color: var(--sub);
+        font-size: 14px;
+        line-height: 2;
+      }
       .report {
         background: var(--card);
         border: 1px solid var(--line);
         border-radius: 12px;
         padding: 20px;
       }
-      h1 {
+      h2 {
         margin: 0 0 6px;
-        font-size: 24px;
+        font-size: 20px;
         color: var(--accent);
       }
       .meta {
@@ -90,6 +116,7 @@ export function renderReportHtml(model: ReportModel): string {
         background: var(--head);
         border: 1px solid var(--line);
         padding: 8px;
+        font-size: 11px;
       }
       td {
         border: 1px solid var(--line);
@@ -102,35 +129,51 @@ export function renderReportHtml(model: ReportModel): string {
         margin-top: 12px;
         font-size: 11px;
         color: var(--sub);
+        line-height: 1.6;
       }
     </style>
   </head>
   <body>
-    <section class="report">
+    <section class="cover">
       <h1>${escapeHtml(model.title)}</h1>
-      <div class="meta">
+      <div class="cover-meta">
         生成日時: ${escapeHtml(model.generatedAt)}<br />
+        対象市区町村: ${citiesList}<br />
         statsDataId: ${escapeHtml(model.statsDataId)}<br />
-        時点: ${escapeHtml(model.timeLabel)}<br />
+        時点: ${escapeHtml(model.timeLabel)}
+      </div>
+    </section>
+
+    <section class="report">
+      <h2>比較結果</h2>
+      <div class="meta">
         指標: ${escapeHtml(model.totalLabel)} / ${escapeHtml(model.kidsLabel)} / 0〜14歳比率
       </div>
       <table>
         <thead>
           <tr>
-            <th style="width: 5%">No</th>
-            <th style="width: 17%">入力市区町村名</th>
-            <th style="width: 17%">解決名</th>
-            <th style="width: 11%">cdArea</th>
-            <th style="width: 17%">人口（総数）</th>
-            <th style="width: 17%">0〜14歳人口</th>
-            <th style="width: 16%">0〜14歳比率</th>
+            <th style="width: 4%">No</th>
+            <th style="width: 13%">入力名</th>
+            <th style="width: 13%">解決名</th>
+            <th style="width: 9%">cdArea</th>
+            <th style="width: 14%">人口（総数）</th>
+            <th style="width: 7%">人口順位</th>
+            <th style="width: 14%">0〜14歳人口</th>
+            <th style="width: 13%">0〜14歳比率</th>
+            <th style="width: 7%">比率順位</th>
           </tr>
         </thead>
         <tbody>
           ${rowsHtml}
         </tbody>
       </table>
-      <div class="footnote">出典: e-Stat API getStatsData / 本レポートはCLIによる自動生成</div>
+      <div class="footnote">
+        出典: e-Stat API getStatsData<br />
+        statsDataId: ${escapeHtml(model.statsDataId)}<br />
+        時点コード: ${escapeHtml(model.timeLabel)}<br />
+        使用分類: ${escapeHtml(model.classInfo)}<br />
+        本レポートはCLIによる自動生成です。
+      </div>
     </section>
   </body>
 </html>`;


### PR DESCRIPTION
## Summary

仕様書（estat_mvp_spec.md）と実装の差分を検証し、10件の不適合を修正しました。

- Exit Code を仕様通りに統一（appId/statsDataId未指定→exit 2、市区町村名解決失敗→exit 3）
- API リトライロジック（3回指数バックオフ）を実装
- PDF タイトル・表紙ページ・注記情報を追加/修正
- 順位計算、都道府県接頭辞除去、ProfileConfig の notes フィールド追加
- search コマンドに --json オプションを追加

## Test plan

- [ ] `npm run build` でビルド成功
- [ ] `node dist/cli.js init` で export 案内確認
- [ ] `node dist/cli.js search --keyword "人口" --json` で JSON 出力確認
- [ ] ESTAT_APP_ID 未設定で実行 → exit code 2 確認
- [ ] 不正な市区町村名で実行 → exit code 3 確認
- [ ] PDF 生成・内容確認（表紙、タイトル、順位列、注記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)