### PR TITLE
docs: CLI実行方法をREADMEに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ e-Stat API から市区町村別の人口データを取得し、比較PDFを出
 npm install
 npx playwright install chromium
 npm run build
+npm link          # estat-report コマンドをグローバルに登録
 ```
 
 ```bash
@@ -22,6 +23,16 @@ estat-report init
 estat-report init
 estat-report search --keyword "人口"
 estat-report report --cities "新宿区,横浜市,大阪市" --statsDataId 0003000001 --out ./out/report.pdf
+```
+
+`npm link` を使わない場合は `npx` 経由でも実行できます。
+
+```bash
+npx estat-report init
+npx estat-report report --cities "新宿区,横浜市,大阪市" --statsDataId 0003000001 --out ./out/report.pdf
+
+# 開発中は tsx で直接実行も可能
+npm run dev -- report --cities "新宿区,横浜市,大阪市"
 ```
 
 ### report オプション


### PR DESCRIPTION
## Summary

`estatーreport` コマンドが見つからないという初心者向けの問題を解決するため、READMEのセットアップ手順を改善しました。

- セットアップ手順に `npm link` ステップを追加
- `npm link` せずに `npx` 経由で実行する方法を記載
- 開発中の `npm run dev` での実行方法も並記

## Test Plan

- README の記載手順に従ってセットアップできることを確認
- `npx estat-report --help` でコマンドが実行できることを確認