### PR TITLE
docs: コードベース全体のドキュメント整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# estat-city-report
+
+e-Stat API と不動産情報ライブラリ API から市区町村データを取得し、比較PDFレポートを生成する CLI ツール。
+
+## 開発コマンド
+
+```bash
+npm run dev -- report --cities "世田谷区,渋谷区"  # 開発実行
+npm run build                                      # TypeScriptコンパイル
+npm test                                           # テスト実行（Vitest）
+npm run test:coverage                              # カバレッジ測定（80%必須）
+```
+
+## ドキュメント
+
+- [アーキテクチャ](docs/architecture.md) — ディレクトリ構成・モジュール構成・データフロー
+- [API連携](docs/api-integration.md) — e-Stat / 不動産情報ライブラリの仕様・認証・キャッシュ
+- [スコアリング](docs/scoring.md) — 正規化・パーセンタイル・重みプリセット・信頼度評価
+- [レポートテンプレート](docs/report-templates.md) — HTML→PDF変換・テンプレート構成・スタイル
+- [テスト](docs/testing.md) — テスト構成・カバレッジ要件・除外ファイル
+- [型定義](docs/types.md) — ReportRow / CityIndicators / CityScoreResult 等の主要型
+- [MVP仕様（初期）](docs/estat_mvp_spec.md) — Phase 0 の初期仕様書

--- a/docs/api-integration.md
+++ b/docs/api-integration.md
@@ -1,0 +1,81 @@
+# API連携
+
+## 環境変数
+
+| 変数名 | 用途 | 必須 |
+|--------|------|------|
+| `ESTAT_APP_ID` | e-Stat API のアプリケーションID | レポート生成時に必須 |
+| `REINFOLIB_API_KEY` | 不動産情報ライブラリ API キー | 価格・災害データ取得時に必須（`--no-price` で省略可） |
+
+`.env` ファイルに設定し、`dotenv` で読み込む。テンプレートは `.env.example` を参照。
+
+## e-Stat API
+
+**クライアント**: `src/estat/client.ts` — `EstatApiClient`
+
+### エンドポイント
+
+ベースURL: `https://api.e-stat.go.jp/rest/3.0/app/json/`
+
+| メソッド | API | 用途 |
+|---------|-----|------|
+| `getStatsList(keyword, limit)` | `getStatsList` | 統計表検索 |
+| `getMetaInfo(statsDataId)` | `getMetaInfo` | メタ情報取得 |
+| `getStatsData(params)` | `getStatsData` | 統計データ取得 |
+
+### ビルトインデータセット
+
+| データ | 統計表ID | 出典 |
+|--------|----------|------|
+| 人口（年齢3区分） | `0003448299` | 国勢調査 令和2年 |
+| 犯罪統計 | `0000020211` | 社会・人口統計体系 K安全 |
+
+定義は `src/config/datasets.ts` で管理。
+
+### リトライ機構
+
+- 最大3回リトライ
+- 指数バックオフ: 1秒 → 2秒 → 4秒
+- HTTP 429/500/502/503 でリトライ
+
+### キャッシュ
+
+- 保存先: `.cache/estat/meta_<statsDataId>.json`
+- TTL: 7日間
+- メタ情報のみキャッシュ対象（統計データ本体はキャッシュしない）
+
+## 不動産情報ライブラリ API
+
+**クライアント**: `src/reinfo/client.ts` — `ReinfoApiClient`
+
+### エンドポイント
+
+ベースURL: `https://www.reinfolib.mlit.go.jp/ex-api/external/`
+
+| API | 用途 |
+|-----|------|
+| `XIT001` | 不動産取引価格情報 |
+| `XIT002` | 都道府県内市区町村一覧 |
+
+### 災害タイルAPI
+
+| API | 用途 | データ形式 |
+|-----|------|----------|
+| `XKT026` | 洪水浸水想定区域 | GeoJSON |
+| `XKT029` | 土砂災害警戒区域 | GeoJSON |
+| `XGT001` | 指定緊急避難場所 | GeoJSON |
+
+タイル座標はレベル14（約1km²）で、市区町村の代表座標から算出。代表座標は `src/reinfo/city-locations.ts` で定義。
+
+### レート制限対策
+
+| 対象 | ディレイ |
+|------|---------|
+| 都市間リクエスト（取引価格） | 200ms |
+| タイル間リクエスト（災害情報） | 300ms |
+
+### キャッシュ
+
+- 保存先: `.cache/reinfo/`
+- TTL: 7日間
+- 取引データをキャッシュ対象

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,108 @@
+# アーキテクチャ
+
+## ディレクトリ構成
+
+```
+src/
+├── cli.ts                 # CLIエントリポイント（Commander.js）
+├── types.ts               # 共通型定義（ReportRow）
+├── errors.ts              # CliError カスタムエラー
+├── utils.ts               # ユーティリティ関数
+├── config/                # 設定管理
+│   ├── config.ts          # estat.config.json の読み書き
+│   └── datasets.ts        # ビルトインデータセットプリセット
+├── estat/                 # e-Stat API 連携
+│   ├── client.ts          # EstatApiClient（リトライ付きHTTP）
+│   ├── cache.ts           # メタ情報キャッシュ（7日TTL）
+│   ├── meta.ts            # メタ情報解析・都市名解決
+│   ├── report-data.ts     # 統計データ → ReportRow 変換
+│   ├── crime-data.ts      # 犯罪統計データ処理
+│   ├── inspect.ts         # 統計表の自動診断
+│   └── merge-crime-scoring.ts  # 犯罪指標マージ
+├── reinfo/                # 不動産情報ライブラリ API 連携
+│   ├── client.ts          # ReinfoApiClient（リトライ付き）
+│   ├── cache.ts           # 取引データキャッシュ（7日TTL）
+│   ├── types.ts           # API関連型定義
+│   ├── price-data.ts      # 取引価格統計
+│   ├── stats.ts           # フィルタリング・分位数計算
+│   ├── city-locations.ts  # 市区町村代表座標
+│   ├── disaster-client.ts # 災害タイルAPI（GeoJSON）
+│   ├── disaster-data.ts   # 災害リスク判定
+│   ├── merge-scoring.ts   # 価格指標マージ
+│   └── merge-disaster-scoring.ts  # 災害指標マージ
+├── scoring/               # スコアリングエンジン
+│   ├── index.ts           # scoreCities() メイン関数
+│   ├── types.ts           # スコアリング型定義
+│   ├── presets.ts         # 重みプリセット・指標定義
+│   ├── normalize.ts       # Min-Max正規化
+│   ├── percentile.ts      # パーセンタイル計算
+│   ├── composite.ts       # 複合スコア計算
+│   └── confidence.ts      # 信頼度評価
+└── report/                # レポート生成
+    ├── html.ts            # 基本HTML生成
+    ├── pdf.ts             # Playwright HTML→PDF変換
+    └── templates/         # スコアリング版テンプレート
+        ├── compose.ts     # レポート全体組成
+        ├── cover.ts       # カバーページ
+        ├── summary.ts     # ランキングサマリー
+        ├── dashboard.ts   # 指標ダッシュボード
+        ├── city-detail.ts # 都市詳細ページ
+        ├── disclaimer.ts  # 免責事項
+        └── styles.ts      # CSS定義
+```
+
+## モジュール構成
+
+| モジュール | 責務 |
+|-----------|------|
+| `config` | 設定ファイルの読み書き、データセットプリセット管理 |
+| `estat` | e-Stat API との通信、メタ情報解析、人口・犯罪データ取得 |
+| `reinfo` | 不動産情報ライブラリ API との通信、価格統計・災害リスク取得 |
+| `scoring` | 多指標の正規化・パーセンタイル・複合スコア・信頼度評価 |
+| `report` | HTMLテンプレート描画、Playwright でのPDF変換 |
+
+## データフロー
+
+```
+CLI入力（--cities "世田谷区,渋谷区"）
+    │
+    ▼
+[Phase 0] 人口統計 ─── e-Stat API (statsDataId: 0003448299)
+    │  → 総人口・0-14歳人口・比率 → CityIndicators[]
+    │
+    ▼
+[Phase 1] 不動産価格 ─── 不動産情報ライブラリ API (XIT001)
+    │  → 取引価格中央値・Q25/Q75・予算内割合
+    │  → mergePriceIntoScoringInput()
+    │
+    ▼
+[Phase 2a] 犯罪統計 ─── e-Stat API (statsDataId: 0000020211)
+    │  → 刑法犯認知件数（千人当たり）
+    │  → mergeCrimeIntoScoringInput()
+    │
+    ▼
+[Phase 2b] 災害リスク ─── 不動産情報ライブラリ API (GeoJSON タイル)
+    │  → 洪水・土砂災害・避難場所
+    │  → mergeDisasterIntoScoringInput()
+    │
+    ▼
+[スコアリング] ─── scoring/index.ts
+    │  → Choice Score（候補内正規化）
+    │  → Baseline Score（パーセンタイル）
+    │  → Composite Score（重み付き総合スコア）
+    │
+    ▼
+[レポート生成] ─── report/templates/ → report/pdf.ts
+    │  → HTML組成（カバー/サマリー/ダッシュボード/詳細/免責）
+    │  → Playwright Chromium で A4 PDF出力
+    │
+    ▼
+  出力ファイル（.pdf）
+```
+
+## 設計原則
+
+- **不変性**: 全型定義に `readonly`、データマージはスプレッド演算子で新規オブジェクト生成
+- **段階的統合**: 各Phase（人口→価格→犯罪→災害）は独立したオプション。`--no-price`, `--no-crime`, `--no-disaster` で個別にスキップ可能
+- **キャッシュ戦略**: メタ情報・取引データを `.cache/` にファイルベースで7日間保持
+- **レート制限対策**: 都市間200ms、タイル間300msのディレイ。APIリトライは指数バックオフ（最大3回）

--- a/docs/report-templates.md
+++ b/docs/report-templates.md
@@ -1,0 +1,69 @@
+# レポートテンプレート
+
+## HTML → PDF 変換
+
+**ファイル**: `src/report/pdf.ts`
+
+Playwright の Chromium を使用して HTML を A4 PDF に変換。
+
+| 設定 | 値 |
+|------|-----|
+| フォーマット | A4 |
+| マージン（上下） | 14mm |
+| マージン（左右） | 10mm |
+| 背景色印刷 | 有効 |
+
+前提条件: `npx playwright install chromium` の実行が必要。
+
+## テンプレート構成
+
+**ディレクトリ**: `src/report/templates/`
+
+スコアリング版レポートの組成は `compose.ts` の `renderScoredReportHtml()` が担当。
+
+```
+renderScoredReportHtml()
+├── renderCover()        — カバーページ（タイトル・生成日時・対象都市・設定情報）
+├── renderSummary()      — サマリー（総合スコアランキング表）
+├── renderDashboard()    — ダッシュボード（指標別スコア詳細テーブル）
+├── renderCityDetail()   — 都市詳細（各都市の個別ページ × N）
+└── renderDisclaimer()   — 免責事項（データ出典・注意事項）
+```
+
+基本（非スコアリング）版は `src/report/html.ts` の `renderReportHtml()` で生成。
+
+## スタイル定義
+
+**ファイル**: `src/report/templates/styles.ts`
+
+### カラー変数
+
+| 変数 | 値 | 用途 |
+|------|-----|------|
+| `--bg` | `#f8fafc` | 背景色 |
+| `--card` | `#ffffff` | カード背景 |
+| `--text` | `#0f172a` | テキスト色 |
+| `--sub` | `#334155` | サブテキスト色 |
+| `--line` | `#cbd5e1` | 罫線色 |
+| `--head` | `#e2e8f0` | テーブルヘッダ背景 |
+| `--accent` | `#1e3a8a` | アクセント色（青） |
+| `--accent-light` | `#dbeafe` | アクセント淡色 |
+| `--success` | `#16a34a` | 成功色（緑） |
+| `--warning` | `#d97706` | 警告色（オレンジ） |
+| `--danger` | `#dc2626` | 危険色（赤） |
+
+### フォント・レイアウト
+
+- フォントファミリー: `Noto Sans JP`, `Hiragino Sans`, `Yu Gothic`, sans-serif
+- 基本フォントサイズ: 12px
+- テーブルフォントサイズ: 11px（ヘッダ: 10px）
+- 行間: 1.6
+- ページ区切り: `.page` クラスに `page-break-after: always`
+
+### 信頼度バッジ
+
+| クラス | 背景色 | テキスト色 |
+|--------|--------|-----------|
+| `.badge-high` | `#dcfce7` | `#166534` |
+| `.badge-medium` | `#fef3c7` | `#92400e` |
+| `.badge-low` | `#fee2e2` | `#991b1b` |

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -1,0 +1,81 @@
+# スコアリングエンジン
+
+スコアリング処理は `src/scoring/` モジュールで実装。メイン関数は `scoreCities()` (`src/scoring/index.ts`)。
+
+## パイプライン
+
+```
+CityIndicators[] (各都市の指標データ)
+    │
+    ├─→ Choice Score（候補内正規化）  ← normalize.ts
+    ├─→ Baseline Score（パーセンタイル）← percentile.ts
+    ├─→ Composite Score（重み付き総合）← composite.ts
+    └─→ Confidence（信頼度評価）      ← confidence.ts
+    │
+    ▼
+CityScoreResult[] (ランク付き結果)
+```
+
+## Choice Score（候補内正規化）
+
+**ファイル**: `src/scoring/normalize.ts`
+
+比較対象の候補セット内で Min-Max 正規化を行い、0〜100のスコアに変換。
+
+- `score = (value - min) / (max - min) * 100`
+- `direction: "lower_better"` の場合: `score = 100 - rawScore`
+- 候補が1つだけの場合: `score = 100`
+- `null` 値の都市は結果から除外
+
+## Baseline Score（パーセンタイル）
+
+**ファイル**: `src/scoring/percentile.ts`
+
+候補セット内でのパーセンタイルランクを計算。
+
+- `percentile = (below + 0.5 * equal) / total * 100`
+- `direction` に応じて反転処理
+- 小数第1位で丸め
+
+## Composite Score（複合スコア）
+
+**ファイル**: `src/scoring/composite.ts`
+
+カテゴリごとの重み付けで総合スコアを算出。
+
+- `compositeScore = Σ(score × categoryWeight) / Σ(categoryWeight)`
+- 欠損指標は除外し、有効指標のみで再正規化
+- 小数第1位で丸め
+
+## 重みプリセット
+
+**ファイル**: `src/scoring/presets.ts`
+
+| プリセット | childcare | price | safety | disaster | transport |
+|-----------|-----------|-------|--------|----------|-----------|
+| 子育て重視 | 0.50 | 0.25 | 0.15 | 0.05 | 0.05 |
+| 価格重視 | 0.15 | 0.50 | 0.15 | 0.10 | 0.10 |
+| 安全重視 | 0.20 | 0.15 | 0.35 | 0.20 | 0.10 |
+
+## 信頼度評価
+
+**ファイル**: `src/scoring/confidence.ts`
+
+| レベル | データ年 | 欠損率 | サンプル数 |
+|--------|---------|--------|-----------|
+| High | ≤2年前 | <10% | ≥30 |
+| Medium | ≤4年前 | <30% | — |
+| Low | 上記以外 | — | — |
+
+## 指標定義一覧
+
+**ファイル**: `src/scoring/presets.ts`
+
+| Phase | ID | ラベル | 単位 | direction | category |
+|-------|-----|--------|------|-----------|----------|
+| 0 | `population_total` | 総人口 | 人 | higher_better | childcare |
+| 0 | `kids_ratio` | 0-14歳比率 | % | higher_better | childcare |
+| 1 | `condo_price_median` | 中古マンション価格（中央値） | 万円 | lower_better | price |
+| 2a | `crime_rate` | 刑法犯認知件数（人口千人当たり） | 件/千人 | lower_better | safety |
+| 2b | `flood_risk` | 洪水・土砂災害リスク | リスクスコア | lower_better | disaster |
+| 2b | `evacuation_sites` | 避難場所数 | 箇所 | higher_better | disaster |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,67 @@
+# テスト
+
+## テストフレームワーク
+
+- **Vitest** (`vitest.config.ts` で設定)
+- カバレッジプロバイダ: V8
+
+## テスト実行
+
+```bash
+npm test                  # ウォッチモードで実行
+npm run test:run          # 1回実行
+npm run test:coverage     # カバレッジ測定付き
+```
+
+## カバレッジ要件
+
+最低80%（statements / branches / functions / lines すべて）。
+
+### カバレッジ除外ファイル
+
+| ファイル | 除外理由 |
+|---------|---------|
+| `src/cli.ts` | CLIエントリポイント（E2E対象） |
+| `src/estat/client.ts` | 外部APIクライアント |
+| `src/estat/cache.ts` | ファイルI/O依存 |
+| `src/report/pdf.ts` | Playwright依存 |
+| `src/types.ts` | 型定義のみ |
+| `src/scoring/types.ts` | 型定義のみ |
+| `src/reinfo/types.ts` | 型定義のみ |
+
+## テストファイル構成
+
+```
+tests/
+├── errors.test.ts                    # CliError
+├── utils.test.ts                     # ユーティリティ関数
+├── config/
+│   ├── config.test.ts                # 設定読み込み
+│   └── datasets.test.ts             # データセットプリセット
+├── estat/
+│   ├── meta.test.ts                  # メタ情報解析
+│   ├── report-data.test.ts           # レポートデータ構築
+│   ├── crime-data.test.ts            # 犯罪統計処理
+│   ├── inspect.test.ts              # 統計表診断
+│   └── merge-crime-scoring.test.ts   # 犯罪指標マージ
+├── reinfo/
+│   ├── client.test.ts                # APIクライアント
+│   ├── cache.test.ts                 # キャッシュ機構
+│   ├── price-data.test.ts            # 価格統計
+│   ├── stats.test.ts                 # フィルタリング・分位数
+│   ├── city-locations.test.ts        # 座標マッピング
+│   ├── disaster-client.test.ts       # タイルAPI
+│   ├── disaster-data.test.ts         # 災害リスク判定
+│   ├── merge-scoring.test.ts         # 価格指標マージ
+│   └── merge-disaster-scoring.test.ts # 災害指標マージ
+├── scoring/
+│   ├── index.test.ts                 # scoreCities()
+│   ├── normalize.test.ts             # Min-Max正規化
+│   ├── percentile.test.ts            # パーセンタイル
+│   ├── composite.test.ts             # 複合スコア
+│   ├── confidence.test.ts            # 信頼度評価
+│   └── presets.test.ts               # プリセット検証
+└── report/
+    ├── html.test.ts                  # 基本HTML生成
+    └── templates.test.ts             # スコアリング版テンプレート
+```

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,94 @@
+# 型定義
+
+全型定義は `readonly` を徹底し、不変性を保証している。
+
+## ReportRow（共通データ行）
+
+**ファイル**: `src/types.ts`
+
+e-Stat から取得した基本データと、各Phaseで追加されるオプショナルフィールドを持つ。
+
+| フィールド | 型 | Phase | 説明 |
+|-----------|-----|-------|------|
+| `cityInput` | `string` | 0 | ユーザー入力の都市名 |
+| `cityResolved` | `string` | 0 | APIで解決された正式名称 |
+| `areaCode` | `string` | 0 | 地域コード |
+| `total` | `number` | 0 | 総人口 |
+| `kids` | `number` | 0 | 0-14歳人口 |
+| `ratio` | `number` | 0 | 0-14歳比率 |
+| `totalRank` | `number` | 0 | 総人口ランク |
+| `ratioRank` | `number` | 0 | 比率ランク |
+| `condoPriceMedian` | `number \| null` | 1 | 取引価格中央値（万円） |
+| `condoPriceQ25` | `number \| null` | 1 | 第1四分位（万円） |
+| `condoPriceQ75` | `number \| null` | 1 | 第3四分位（万円） |
+| `condoPriceCount` | `number \| null` | 1 | 取引件数 |
+| `affordabilityRate` | `number \| null` | 1 | 予算内取引割合（%） |
+| `propertyTypeLabel` | `string \| null` | 1 | 物件タイプラベル |
+| `crimeRate` | `number \| null` | 2a | 刑法犯認知件数（千人当たり） |
+| `floodRisk` | `boolean \| null` | 2b | 洪水浸水リスクの有無 |
+| `landslideRisk` | `boolean \| null` | 2b | 土砂災害リスクの有無 |
+| `evacuationSiteCount` | `number \| null` | 2b | 指定緊急避難場所数 |
+
+## 不動産API型定義
+
+**ファイル**: `src/reinfo/types.ts`
+
+### ReinfoTradeRecord
+
+XIT001 API レスポンスの取引レコード。`Type`, `TradePrice`, `Municipality` 等のフィールドを持つ。
+
+### CondoPriceStats
+
+取引価格の統計結果。中央値・四分位・件数・年度・予算内割合を含む。
+
+### PropertyType
+
+物件タイプの列挙: `"condo" | "house" | "land" | "all"`
+
+対応ラベル（`PROPERTY_TYPE_LABELS`）:
+
+| 値 | ラベル |
+|-----|--------|
+| `condo` | 中古マンション等 |
+| `house` | 中古戸建住宅 |
+| `land` | 宅地(土地) |
+| `all` | 全種別 |
+
+## スコアリング型定義
+
+**ファイル**: `src/scoring/types.ts`
+
+### CityIndicators
+
+都市ごとの全指標データ。`cityName`, `areaCode`, `indicators: ReadonlyArray<IndicatorValue>` を持つ。
+
+### IndicatorDefinition
+
+指標のメタ定義。`id`, `label`, `unit`, `direction`（higher_better / lower_better）, `category`, `precision` を持つ。
+
+### IndicatorValue
+
+単一の指標データポイント。`indicatorId`, `rawValue`（null許容）, `dataYear`, `sourceId` を持つ。
+
+### CityScoreResult
+
+都市ごとのスコアリング結果。
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `cityName` | `string` | 都市名 |
+| `areaCode` | `string` | 地域コード |
+| `baseline` | `ReadonlyArray<BaselineScore>` | パーセンタイルスコア |
+| `choice` | `ReadonlyArray<ChoiceScore>` | 候補内正規化スコア |
+| `compositeScore` | `number` | 重み付き総合スコア |
+| `confidence` | `ConfidenceResult` | 信頼度評価 |
+| `rank` | `number` | 総合ランク |
+| `notes` | `ReadonlyArray<string>` | 注記 |
+
+### WeightPreset
+
+重みプリセット。`name`, `label`, `weights: Record<IndicatorCategory, number>` を持つ。
+
+### IndicatorCategory
+
+指標カテゴリの列挙: `"childcare" | "price" | "safety" | "disaster" | "transport"`


### PR DESCRIPTION
## 概要

プロジェクトの仕様・アーキテクチャ・API仕様を体系的にドキュメント化しました。プロジェクトローカルのCLAUDE.mdと6つのドキュメントファイルを追加。

## 変更内容

- **CLAUDE.md** — プロジェクト概要・開発コマンド・ドキュメントリンク集
- **docs/architecture.md** — ディレクトリ構成・モジュール責務・データフロー図
- **docs/api-integration.md** — e-Stat・不動産API仕様・認証・キャッシュ・レート制限
- **docs/scoring.md** — スコアリングパイプライン・正規化・プリセット・信頼度評価
- **docs/report-templates.md** — HTML→PDF変換・テンプレート構成・スタイル
- **docs/testing.md** — テスト実行・カバレッジ要件・ファイル対応
- **docs/types.md** — 主要型定義（ReportRow・CityIndicators・CityScoreResult等）

## テスト

既存のdocs/estat_mvp_spec.mdとの矛盾がないことを確認。