### PR TITLE
fix: e-Stat API マルチカテゴリ対応とスコア付きデフォルト化

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm link          # estat-report コマンドをグローバルに登録
 ```bash
 estat-report init
 # .env または環境変数で ESTAT_APP_ID を設定
+# 不動産価格・災害リスクデータも使う場合は REINFOLIB_API_KEY も設定
 ```
 
 > `estat-report init` が生成する `estat.config.json` にはデフォルトの統計表IDが設定済みです。通常は編集不要です。
@@ -24,10 +25,13 @@ estat-report init
 
 ```bash
 estat-report report --cities "新宿区,横浜市,大阪市"
-estat-report report --cities "新宿区,横浜市,大阪市" --scored --out ./out/report.pdf
+estat-report report --cities "新宿区,横浜市,大阪市" --out ./out/report.pdf
+estat-report report --cities "新宿区,横浜市,大阪市" --no-scored  # スコアなし基本レポート
 ```
 
+デフォルトでスコア付きレポート（人口・犯罪統計・不動産価格・災害リスク）を生成します。
 人口データ・犯罪統計のデータセットはビルトインで定義済みのため、`--statsDataId` の指定は不要です。
+不動産価格・災害リスクデータには `REINFOLIB_API_KEY` が必要です（未設定時は警告付きでスキップ）。
 
 ### search — 統計表の検索
 
@@ -59,7 +63,10 @@ npm run dev -- report --cities "新宿区,横浜市,大阪市"
 - `--statsDataId <ID>` (省略時はビルトインデフォルトを使用)
 - `--profile <name>` (`estat.config.json` の profile)
 - `--out <path>`
-- `--scored` (スコアリング付きレポート)
+- `--no-scored` (スコアなし基本レポートで生成)
+- `--no-price` (不動産価格データなしで実行)
+- `--no-crime` (犯罪統計データなしで実行)
+- `--no-disaster` (災害リスクデータなしで実行)
 - `--classId <id>` / `--totalCode <code>` / `--kidsCode <code>` (年齢分類を手動指定)
 - `--timeCode <code>` (時間軸を手動指定)
 - `--crimeStatsId <ID>` (犯罪統計の統計表IDを上書き)
@@ -84,14 +91,14 @@ npm run dev -- report --cities "新宿区,横浜市,大阪市"
     "population": {
       "statsDataId": "0003448299",
       "selectors": {
-        "classId": "cat01",
-        "totalCode": "000",
-        "kidsCode": "001"
+        "classId": "cat01"
       }
     }
   }
 }
 ```
+
+`totalCode`/`kidsCode` は自動検出されるため、通常は `classId` のみで十分です。
 
 ## キャッシュ
 

--- a/src/config/datasets.ts
+++ b/src/config/datasets.ts
@@ -20,8 +20,6 @@ export const DATASETS = {
     label: "国勢調査 年齢（3区分）人口（令和2年）",
     selectors: {
       classId: "cat01",
-      totalCode: "000",
-      kidsCode: "001",
     },
   },
   /** 社会・人口統計体系 市区町村データ K安全（刑法犯認知件数） */

--- a/src/estat/meta.ts
+++ b/src/estat/meta.ts
@@ -299,6 +299,63 @@ export function resolveLatestTime(classObjs: ClassObj[], explicitCode?: string):
   };
 }
 
+export interface DefaultFilter {
+  readonly paramName: string;
+  readonly code: string;
+}
+
+/** 「総数」「実数」など、デフォルト（集約）値と見なせるラベルのスコアを返す */
+function isDefaultLabel(name: string): number {
+  const totalScore = isTotalLabel(name);
+  if (totalScore > 0) {
+    return totalScore;
+  }
+  const normalized = normalizeLabel(name);
+  if (normalized === "実数") {
+    return 100;
+  }
+  if (normalized.includes("実数")) {
+    return 80;
+  }
+  if (normalized === "人" || normalized === "人口") {
+    return 60;
+  }
+  return 0;
+}
+
+/** 分類内で「総数」「実数」に該当するデフォルト項目を探す */
+function findDefaultItem(cls: ClassObj): ClassItem | null {
+  const scored = [...cls.items]
+    .map((item) => ({ ...item, score: isDefaultLabel(item.name) }))
+    .filter((item) => item.score > 0)
+    .sort((a, b) => b.score - a.score);
+  return scored.length > 0 ? scored[0] : null;
+}
+
+/**
+ * 指定された分類以外のcat/tab分類について、デフォルト（総数/実数）コードを検出する。
+ * APIパラメータに追加することで、不要なクロス集計行（男女別、構成比等）を排除する。
+ */
+export function resolveDefaultFilters(
+  classObjs: ReadonlyArray<ClassObj>,
+  excludeClassIds: ReadonlySet<string>,
+): ReadonlyArray<DefaultFilter> {
+  return classObjs
+    .filter((cls) => !excludeClassIds.has(cls.id))
+    .filter((cls) => cls.id.startsWith("cat") || cls.id === "tab")
+    .map((cls) => {
+      const defaultItem = findDefaultItem(cls);
+      if (!defaultItem) {
+        return null;
+      }
+      return {
+        paramName: toCdParamName(cls.id),
+        code: defaultItem.code,
+      };
+    })
+    .filter((f): f is DefaultFilter => f !== null);
+}
+
 function isTotalLabel(name: string): number {
   const normalized = normalizeLabel(name);
   if (normalized === "総数") {
@@ -462,7 +519,10 @@ export function valuesByArea(values: DataValue[], timeCode: string): Map<string,
     if (!row.area || row.value === null) {
       continue;
     }
-    map.set(row.area, row.value);
+    // 防御: 同一areaの重複がある場合は最初の値を保持（上書きしない）
+    if (!map.has(row.area)) {
+      map.set(row.area, row.value);
+    }
   }
 
   return map;

--- a/tests/config/datasets.test.ts
+++ b/tests/config/datasets.test.ts
@@ -9,8 +9,9 @@ describe("DATASETS", () => {
   it("population のセレクタが定義されている", () => {
     expect(DATASETS.population.selectors).toBeDefined();
     expect(DATASETS.population.selectors.classId).toBe("cat01");
-    expect(DATASETS.population.selectors.totalCode).toBe("000");
-    expect(DATASETS.population.selectors.kidsCode).toBe("001");
+    // totalCode/kidsCode は自動検出に委ねるため未定義
+    expect(DATASETS.population.selectors.totalCode).toBeUndefined();
+    expect(DATASETS.population.selectors.kidsCode).toBeUndefined();
   });
 
   it("crime の statsDataId は10桁の数字文字列", () => {


### PR DESCRIPTION
## 概要

レポート生成時の2つの重大なバグを修正しました：

**Bug 1: 0〜14歳比率が0.02%と表示される問題**
- 原因：e-Stat API が複数のカテゴリ軸（cat02男女, tab表章項目）を返すため、`valuesByArea` が最後の値（構成比）で上書きしていた
- 修正：APIリクエスト時に cat02/tab の「総数」「実数」を自動フィルタ、レスポンス処理では最初の値を保持

**Bug 2: マンション価格・犯罪統計が表示されない**
- 原因：ユーザーが `--scored` オプションを使用していなかった
- 修正：`--scored` をデフォルト化、`--no-scored` で基本レポートを選択可能に
- REINFOLIB_API_KEY 未設定時は警告を出してスキップ（硬いエラーではなく）

## 変更内容

- `meta.ts`: `resolveDefaultFilters()` 追加、`valuesByArea()` 防御修正
- `report-data.ts`: `fetchMetricByArea` に extraFilters を追加
- `cli.ts`: `--no-scored` 化、API キーソフトフォールバック
- `datasets.ts`: 不要な `totalCode`/`kidsCode` を削除
- `README.md`: オプション・使用方法を更新
- テスト: 8件の新規テスト（防御修正 + マルチカテゴリ検証）

## テスト結果

全256テスト通過 ✅