### PR TITLE
fix: 欠損指標の修正 - タイルAPI・座標フォールバック・エラーハンドリング

### DIFF
--- a/src/reinfo/client.ts
+++ b/src/reinfo/client.ts
@@ -109,6 +109,7 @@ export class ReinfoApiClient {
   /** 防災タイルAPI（XKT026/XKT029/XGT001等）からGeoJSONを取得 */
   async fetchTile(endpoint: string, tile: TileCoord): Promise<GeoJsonFeatureCollection> {
     return this.request<GeoJsonFeatureCollection>(endpoint, {
+      response_format: "geojson",
       z: String(tile.z),
       x: String(tile.x),
       y: String(tile.y),

--- a/src/reinfo/disaster-client.ts
+++ b/src/reinfo/disaster-client.ts
@@ -65,9 +65,18 @@ export async function fetchDisasterRisk(
   const tile = latLngToTile(location.lat, location.lng, zoom);
 
   const [floodData, landslideData, evacuationData] = await Promise.all([
-    client.fetchTile("XKT026", tile).catch(() => null),
-    client.fetchTile("XKT029", tile).catch(() => null),
-    sleep(TILE_DELAY_MS).then(() => client.fetchTile("XGT001", tile).catch(() => null)),
+    client.fetchTile("XKT026", tile).catch((err) => {
+      console.warn(`[warn] 洪水浸水想定区域(XKT026)の取得に失敗: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }),
+    client.fetchTile("XKT029", tile).catch((err) => {
+      console.warn(`[warn] 土砂災害警戒区域(XKT029)の取得に失敗: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    }),
+    sleep(TILE_DELAY_MS).then(() => client.fetchTile("XGT001", tile).catch((err) => {
+      console.warn(`[warn] 指定緊急避難場所(XGT001)の取得に失敗: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    })),
   ]);
 
   const floodRisk = hasFeatures(floodData);

--- a/src/reinfo/geocode.ts
+++ b/src/reinfo/geocode.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+import { CityLocation } from "./city-locations";
+
+/** 国土地理院 住所検索APIのレスポンス要素 */
+interface GsiGeocodeResult {
+  readonly geometry: {
+    readonly coordinates: readonly [number, number]; // [lng, lat]
+  };
+  readonly properties: {
+    readonly title: string;
+  };
+}
+
+const GSI_GEOCODE_URL = "https://msearch.gsi.go.jp/address-search/AddressSearch";
+const TIMEOUT_MS = 10000;
+
+/**
+ * 国土地理院の住所検索APIで市区町村名から座標を取得する。
+ * APIキー不要。取得失敗時はnullを返す。
+ */
+export async function geocodeCityName(cityName: string): Promise<CityLocation | null> {
+  try {
+    const response = await axios.get<ReadonlyArray<GsiGeocodeResult>>(GSI_GEOCODE_URL, {
+      params: { q: cityName },
+      timeout: TIMEOUT_MS,
+    });
+
+    const results = response.data;
+    if (!Array.isArray(results) || results.length === 0) {
+      return null;
+    }
+
+    const first = results[0];
+    const [lng, lat] = first.geometry.coordinates;
+    if (typeof lat !== "number" || typeof lng !== "number") {
+      return null;
+    }
+
+    return { lat, lng };
+  } catch {
+    return null;
+  }
+}

--- a/tests/reinfo/city-locations.test.ts
+++ b/tests/reinfo/city-locations.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { getCityLocation, CITY_LOCATIONS } from "../../src/reinfo/city-locations";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getCityLocation, getCityLocationAsync, CITY_LOCATIONS } from "../../src/reinfo/city-locations";
 
 describe("getCityLocation", () => {
   it("登録済みの市区町村コードで座標を返す", () => {
@@ -26,5 +26,43 @@ describe("getCityLocation", () => {
     for (const code of CITY_LOCATIONS.keys()) {
       expect(code).toMatch(/^\d{5}$/);
     }
+  });
+});
+
+describe("getCityLocationAsync", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("静的テーブルに登録済みならAPIを呼ばずに返す", async () => {
+    const loc = await getCityLocationAsync("13104");
+    expect(loc).not.toBeNull();
+    expect(loc!.lat).toBeCloseTo(35.69, 1);
+  });
+
+  it("未登録でcityNameなしならnullを返す", async () => {
+    const loc = await getCityLocationAsync("99999");
+    expect(loc).toBeNull();
+  });
+
+  it("未登録でcityNameありなら国土地理院APIにフォールバックする", async () => {
+    vi.doMock("../../src/reinfo/geocode", () => ({
+      geocodeCityName: vi.fn().mockResolvedValue({ lat: 34.9587, lng: 137.0851 }),
+    }));
+
+    const { getCityLocationAsync: fn } = await import("../../src/reinfo/city-locations");
+    const loc = await fn("23212", "安城市");
+    expect(loc).not.toBeNull();
+    expect(loc!.lat).toBeCloseTo(34.96, 1);
+  });
+
+  it("ジオコーディング失敗時にnullを返す", async () => {
+    vi.doMock("../../src/reinfo/geocode", () => ({
+      geocodeCityName: vi.fn().mockResolvedValue(null),
+    }));
+
+    const { getCityLocationAsync: fn } = await import("../../src/reinfo/city-locations");
+    const loc = await fn("99999", "存在しない市");
+    expect(loc).toBeNull();
   });
 });

--- a/tests/reinfo/client.test.ts
+++ b/tests/reinfo/client.test.ts
@@ -105,6 +105,38 @@ describe("ReinfoApiClient", () => {
     });
   });
 
+  describe("fetchTile", () => {
+    it("response_format=geojsonパラメータを含めてリクエストする", async () => {
+      const mockGeoJson = { type: "FeatureCollection", features: [] };
+      mockAxiosInstance.get.mockResolvedValue({ data: mockGeoJson });
+
+      const client = new ReinfoApiClient("test-key");
+      await client.fetchTile("XKT026", { z: 14, x: 14430, y: 6491 });
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith("XKT026", {
+        params: {
+          response_format: "geojson",
+          z: "14",
+          x: "14430",
+          y: "6491",
+        },
+      });
+    });
+
+    it("GeoJSONレスポンスを返す", async () => {
+      const mockGeoJson = {
+        type: "FeatureCollection",
+        features: [{ type: "Feature", geometry: { type: "Polygon", coordinates: [] }, properties: {} }],
+      };
+      mockAxiosInstance.get.mockResolvedValue({ data: mockGeoJson });
+
+      const client = new ReinfoApiClient("test-key");
+      const result = await client.fetchTile("XGT001", { z: 14, x: 14430, y: 6491 });
+
+      expect(result.features).toHaveLength(1);
+    });
+  });
+
   describe("エラーハンドリング", () => {
     it("401エラーで認証エラーメッセージをスローする", async () => {
       const axiosError = {

--- a/tests/reinfo/geocode.test.ts
+++ b/tests/reinfo/geocode.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import axios from "axios";
+import { geocodeCityName } from "../../src/reinfo/geocode";
+
+vi.mock("axios");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("geocodeCityName", () => {
+  it("正常なレスポンスで座標を返す", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [
+        {
+          geometry: { coordinates: [137.0851, 34.9587] },
+          properties: { title: "愛知県安城市" },
+        },
+      ],
+    });
+
+    const result = await geocodeCityName("安城市");
+    expect(result).not.toBeNull();
+    expect(result!.lat).toBeCloseTo(34.96, 1);
+    expect(result!.lng).toBeCloseTo(137.09, 1);
+  });
+
+  it("空の結果配列でnullを返す", async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: [] });
+
+    const result = await geocodeCityName("存在しない市");
+    expect(result).toBeNull();
+  });
+
+  it("APIエラーでnullを返す", async () => {
+    vi.mocked(axios.get).mockRejectedValue(new Error("Network error"));
+
+    const result = await geocodeCityName("安城市");
+    expect(result).toBeNull();
+  });
+
+  it("不正なレスポンス形式でnullを返す", async () => {
+    vi.mocked(axios.get).mockResolvedValue({ data: "invalid" });
+
+    const result = await geocodeCityName("安城市");
+    expect(result).toBeNull();
+  });
+
+  it("GeoJSON標準の[lng, lat]順序を正しくパースする", async () => {
+    vi.mocked(axios.get).mockResolvedValue({
+      data: [
+        {
+          geometry: { coordinates: [139.6917, 35.6895] },
+          properties: { title: "東京都" },
+        },
+      ],
+    });
+
+    const result = await geocodeCityName("東京");
+    expect(result).not.toBeNull();
+    expect(result!.lat).toBeCloseTo(35.69, 1);
+    expect(result!.lng).toBeCloseTo(139.69, 1);
+  });
+});


### PR DESCRIPTION
## Summary

`report --cities "安城市,戸田市,佐久市"` 実行時に6指標中3件（刑法犯認知件数・洪水土砂災害リスク・避難場所数）がレポートに反映されない問題を修正。

### 修正内容

- **`fetchTile` に `response_format=geojson` 追加**: 防災タイルAPI（XKT026/XKT029/XGT001）の必須パラメータが欠落しており、400エラーが `.catch(() => null)` で握りつぶされていた
- **国土地理院ジオコーディングAPIによる座標フォールバック**: `city-locations.ts` の静的テーブル（約60件）に無い市区町村の座標を、国土地理院APIで動的に取得する仕組みを追加
- **cli.ts のエラーハンドリング改善**: 不動産・犯罪・災害の各データ取得ブロックにtry-catchを追加し、1つの失敗が他のデータ取得やレポート生成を中断しないよう改善
- **犯罪統計データの診断ログ追加**: `buildCrimeData` が空Mapを返す原因を特定するための警告ログを追加
- **災害リスク取得のエラーログ追加**: `.catch(() => null)` を `.catch((err) => { console.warn(...); return null; })` に変更

## Test plan

- [x] 型チェック通過 (`tsc --noEmit`)
- [x] 既存テスト全393件通過 (`npm test`)
- [x] 新規テスト追加: geocode.ts (5件), city-locations.ts (4件), client.ts (2件)
- [ ] `npm run dev -- report --cities "安城市,戸田市,佐久市"` で全指標が出力されることを確認
- [ ] `npm run dev -- report --cities "世田谷区,渋谷区"` で既存の動作が壊れていないことを確認