### PR TITLE
feat: レポートに評価ナラティブを追加

### DIFF
--- a/src/report/narrative.ts
+++ b/src/report/narrative.ts
@@ -1,0 +1,253 @@
+import {
+  CityScoreResult,
+  ChoiceScore,
+  IndicatorDefinition,
+} from "../scoring/types";
+
+/** スコア分類の閾値 */
+const STRONG_THRESHOLD = 70;
+const WEAK_THRESHOLD = 30;
+const CLOSE_GAP = 5;
+const LARGE_GAP = 20;
+
+/** 指標の評価分類 */
+type IndicatorRating = "strong" | "neutral" | "weak";
+
+/** 分類済み指標 */
+interface ClassifiedIndicator {
+  readonly label: string;
+  readonly score: number;
+  readonly rating: IndicatorRating;
+}
+
+/** Choice Score を強み/中立/弱みに分類する */
+function classifyIndicators(
+  choiceScores: ReadonlyArray<ChoiceScore>,
+  definitions: ReadonlyArray<IndicatorDefinition>
+): ReadonlyArray<ClassifiedIndicator> {
+  return choiceScores
+    .map((cs) => {
+      const def = definitions.find((d) => d.id === cs.indicatorId);
+      if (!def) return null;
+      const rating: IndicatorRating =
+        cs.score >= STRONG_THRESHOLD
+          ? "strong"
+          : cs.score <= WEAK_THRESHOLD
+            ? "weak"
+            : "neutral";
+      return { label: def.label, score: cs.score, rating };
+    })
+    .filter((item): item is ClassifiedIndicator => item !== null);
+}
+
+/** 分類済み指標をグループ分けする */
+function groupByRating(indicators: ReadonlyArray<ClassifiedIndicator>): {
+  readonly strengths: ReadonlyArray<ClassifiedIndicator>;
+  readonly weaknesses: ReadonlyArray<ClassifiedIndicator>;
+} {
+  return {
+    strengths: indicators.filter((i) => i.rating === "strong"),
+    weaknesses: indicators.filter((i) => i.rating === "weak"),
+  };
+}
+
+// ─── 都市別ナラティブ ───
+
+interface CityNarrativeInput {
+  readonly cityName: string;
+  readonly compositeScore: number;
+  readonly rank: number;
+  readonly totalCities: number;
+  readonly choiceScores: ReadonlyArray<ChoiceScore>;
+  readonly definitions: ReadonlyArray<IndicatorDefinition>;
+  readonly confidenceLevel: "high" | "medium" | "low";
+  readonly missingIndicatorCount: number;
+}
+
+/** 総合評価文 */
+function buildOverallSentence(input: CityNarrativeInput): string {
+  const { cityName, compositeScore, rank, totalCities } = input;
+  const score = compositeScore.toFixed(1);
+
+  if (totalCities === 1) {
+    return `${cityName}の総合スコアは${score}点です。`;
+  }
+  if (rank === 1) {
+    return `${cityName}は総合スコア${score}点で、候補${totalCities}市区町村の中で最も高い評価となりました。`;
+  }
+  if (rank === totalCities) {
+    return `${cityName}は総合スコア${score}点で、候補${totalCities}市区町村の中で最も低い評価となりました。`;
+  }
+  return `${cityName}は総合スコア${score}点で、候補${totalCities}市区町村中${rank}位の評価です。`;
+}
+
+/** 強み・弱み・中立に基づく文章を生成 */
+function buildStrengthWeaknessSentence(
+  classified: ReadonlyArray<ClassifiedIndicator>
+): string {
+  const { strengths, weaknesses } = groupByRating(classified);
+
+  if (strengths.length === 0 && weaknesses.length === 0) {
+    return "各指標は候補内で平均的な水準にあります。";
+  }
+
+  const parts: string[] = [];
+  if (strengths.length > 0) {
+    const labels = strengths.map((s) => s.label).join("、");
+    parts.push(`${labels}が強みです。`);
+  }
+  if (weaknesses.length > 0) {
+    const labels = weaknesses.map((w) => w.label).join("、");
+    parts.push(`一方、${labels}は相対的に課題があります。`);
+  }
+  return parts.join("");
+}
+
+/** 信頼度に基づく注記 */
+function buildConfidenceCaveat(
+  confidenceLevel: "high" | "medium" | "low",
+  missingCount: number
+): string {
+  if (confidenceLevel === "low") {
+    const missingNote =
+      missingCount > 0 ? `（${missingCount}件の指標データが欠損）` : "";
+    return `なお、データの信頼度が低いため${missingNote}、参考値としてご確認ください。`;
+  }
+  if (missingCount > 0) {
+    return `※ ${missingCount}件の指標データが欠損しているため、評価の精度に限りがあります。`;
+  }
+  return "";
+}
+
+/** 都市別ナラティブを生成する */
+export function generateCityNarrative(
+  result: CityScoreResult,
+  definitions: ReadonlyArray<IndicatorDefinition>,
+  totalCities: number
+): string {
+  const classified = classifyIndicators(result.choice, definitions);
+  const totalIndicators = definitions.length;
+  const availableIndicators = result.choice.length;
+  const missingCount = totalIndicators - availableIndicators;
+
+  const input: CityNarrativeInput = {
+    cityName: result.cityName,
+    compositeScore: result.compositeScore,
+    rank: result.rank,
+    totalCities,
+    choiceScores: result.choice,
+    definitions,
+    confidenceLevel: result.confidence.level,
+    missingIndicatorCount: missingCount,
+  };
+
+  const sentences: string[] = [
+    buildOverallSentence(input),
+    buildStrengthWeaknessSentence(classified),
+  ];
+
+  const caveat = buildConfidenceCaveat(input.confidenceLevel, missingCount);
+  if (caveat) {
+    sentences.push(caveat);
+  }
+
+  return sentences.join("");
+}
+
+// ─── 比較ナラティブ ───
+
+/** スコア差の大きさを判定 */
+function classifyGap(gap: number): "close" | "moderate" | "large" {
+  if (gap <= CLOSE_GAP) return "close";
+  if (gap >= LARGE_GAP) return "large";
+  return "moderate";
+}
+
+/** 1位の都市に基づく結論文 */
+function buildWinnerSentence(
+  results: ReadonlyArray<CityScoreResult>
+): string {
+  const sorted = [...results].sort((a, b) => a.rank - b.rank);
+  const first = sorted[0];
+
+  if (sorted.length === 1) {
+    return `${first.cityName}の単独評価です。比較対象がないため、各指標の絶対的な水準をご確認ください。`;
+  }
+
+  const second = sorted[1];
+  const gap = first.compositeScore - second.compositeScore;
+
+  // 全都市同スコア
+  const allSame = sorted.every(
+    (c) => c.compositeScore === first.compositeScore
+  );
+  if (allSame) {
+    return "候補間の総合スコアに差はなく、いずれも同等の評価となりました。";
+  }
+
+  const gapClass = classifyGap(gap);
+  if (gapClass === "close") {
+    return `${first.cityName}が総合1位ですが、${second.cityName}との差は${gap.toFixed(1)}点と僅差であり、実質的にほぼ同等の評価です。`;
+  }
+  if (gapClass === "large") {
+    return `${first.cityName}が総合1位（${first.compositeScore.toFixed(1)}点）で、2位の${second.cityName}（${second.compositeScore.toFixed(1)}点）に${gap.toFixed(1)}点の大きな差をつけています。`;
+  }
+  return `総合的に${first.cityName}（${first.compositeScore.toFixed(1)}点）が最も高い評価で、${second.cityName}（${second.compositeScore.toFixed(1)}点）が続きます。`;
+}
+
+/** 指標ごとのリーダーを特定し、トレードオフ文を生成 */
+function buildTradeoffSentence(
+  results: ReadonlyArray<CityScoreResult>,
+  definitions: ReadonlyArray<IndicatorDefinition>
+): string {
+  if (results.length < 2) return "";
+
+  // 指標ごとに最高スコアの都市を特定
+  const leaderMap = new Map<string, string[]>();
+
+  for (const def of definitions) {
+    let bestCity = "";
+    let bestScore = -1;
+
+    for (const r of results) {
+      const cs = r.choice.find((c) => c.indicatorId === def.id);
+      if (cs && cs.score > bestScore) {
+        bestScore = cs.score;
+        bestCity = r.cityName;
+      }
+    }
+
+    if (bestCity) {
+      const existing = leaderMap.get(bestCity) ?? [];
+      leaderMap.set(bestCity, [...existing, def.label]);
+    }
+  }
+
+  // 全指標で同一都市がリード
+  if (leaderMap.size === 1) {
+    const [leader] = leaderMap.keys();
+    return `${leader}は全ての指標で候補内最高値を記録しています。`;
+  }
+
+  const parts = Array.from(leaderMap.entries()).map(
+    ([city, labels]) => `${city}は${labels.join("・")}で優位`
+  );
+
+  if (parts.length === 2) {
+    return `${parts[0]}、${parts[1]}であり、優先する観点によって選択が分かれます。`;
+  }
+  return `${parts.join("、")}となっています。`;
+}
+
+/** 比較ナラティブを生成する */
+export function generateComparisonNarrative(
+  results: ReadonlyArray<CityScoreResult>,
+  definitions: ReadonlyArray<IndicatorDefinition>
+): string {
+  return [
+    buildWinnerSentence(results),
+    buildTradeoffSentence(results, definitions),
+  ]
+    .filter((s) => s.length > 0)
+    .join("");
+}

--- a/src/report/templates/city-detail.ts
+++ b/src/report/templates/city-detail.ts
@@ -1,11 +1,13 @@
 import { CityScoreResult, IndicatorDefinition, ConfidenceLevel } from "../../scoring/types";
 import { escapeHtml } from "../../utils";
 import { ReportRow } from "../../types";
+import { generateCityNarrative } from "../narrative";
 
 export interface CityDetailModel {
   readonly result: CityScoreResult;
   readonly definition: ReadonlyArray<IndicatorDefinition>;
   readonly rawRow: ReportRow;
+  readonly totalCities: number;
 }
 
 function confidenceLabel(level: ConfidenceLevel): string {
@@ -121,6 +123,11 @@ export function renderCityDetail(model: CityDetailModel): string {
           ${indicatorRows}
         </tbody>
       </table>
+
+      <div class="narrative" style="margin-top:12px;">
+        <h3>評価コメント</h3>
+        <p>${escapeHtml(generateCityNarrative(result, model.definition, model.totalCities))}</p>
+      </div>
 
       <h3 style="margin-top:12px;">注意事項</h3>
       <ul class="note" style="padding-left:16px;">

--- a/src/report/templates/compose.ts
+++ b/src/report/templates/compose.ts
@@ -49,6 +49,7 @@ export function renderScoredReportHtml(model: ScoredReportModel): string {
   const summary = renderSummary({
     results: model.results,
     presetLabel: model.preset.label,
+    definitions: model.definitions,
   });
 
   const dashboard = renderDashboard({
@@ -66,6 +67,7 @@ export function renderScoredReportHtml(model: ScoredReportModel): string {
         result,
         definition: model.definitions,
         rawRow,
+        totalCities: model.results.length,
       });
     })
     .join("\n");

--- a/src/report/templates/styles.ts
+++ b/src/report/templates/styles.ts
@@ -73,5 +73,22 @@ export function baseStyles(): string {
     }
     .meta { color: var(--sub); font-size: 11px; margin-bottom: 12px; }
     .note { color: var(--sub); font-size: 10px; line-height: 1.5; }
+    .narrative {
+      background: var(--accent-light);
+      border-left: 3px solid var(--accent);
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 4px 4px 0;
+    }
+    .narrative h3 {
+      font-size: 12px;
+      color: var(--accent);
+      margin-bottom: 6px;
+    }
+    .narrative p {
+      font-size: 11px;
+      line-height: 1.8;
+      color: var(--text);
+    }
   `;
 }

--- a/src/report/templates/summary.ts
+++ b/src/report/templates/summary.ts
@@ -1,9 +1,11 @@
-import { CityScoreResult, ConfidenceLevel } from "../../scoring/types";
+import { CityScoreResult, ConfidenceLevel, IndicatorDefinition } from "../../scoring/types";
 import { escapeHtml } from "../../utils";
+import { generateComparisonNarrative } from "../narrative";
 
 export interface SummaryModel {
   readonly results: ReadonlyArray<CityScoreResult>;
   readonly presetLabel: string;
+  readonly definitions: ReadonlyArray<IndicatorDefinition>;
 }
 
 function confidenceBadge(level: ConfidenceLevel): string {
@@ -54,6 +56,11 @@ export function renderSummary(model: SummaryModel): string {
           ${rankingRows}
         </tbody>
       </table>
+
+      <div class="narrative" style="margin-top:12px;">
+        <h3>総合評価</h3>
+        <p>${escapeHtml(generateComparisonNarrative(model.results, model.definitions))}</p>
+      </div>
 
       <div class="note" style="margin-top:12px;">
         ※ 総合スコアは候補内での相対比較値（0-100）です。全国基準ではありません。<br>

--- a/tests/report/narrative.test.ts
+++ b/tests/report/narrative.test.ts
@@ -1,0 +1,314 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateCityNarrative,
+  generateComparisonNarrative,
+} from "../../src/report/narrative";
+import {
+  CityScoreResult,
+  IndicatorDefinition,
+} from "../../src/scoring/types";
+
+const definitions: ReadonlyArray<IndicatorDefinition> = [
+  {
+    id: "population_total",
+    label: "総人口",
+    unit: "人",
+    direction: "higher_better",
+    category: "childcare",
+    precision: 0,
+  },
+  {
+    id: "kids_ratio",
+    label: "0-14歳比率",
+    unit: "%",
+    direction: "higher_better",
+    category: "childcare",
+    precision: 1,
+  },
+  {
+    id: "condo_price_median",
+    label: "中古マンション価格（中央値）",
+    unit: "万円",
+    direction: "lower_better",
+    category: "price",
+    precision: 0,
+  },
+];
+
+function makeResult(
+  overrides: Partial<CityScoreResult> & { cityName: string }
+): CityScoreResult {
+  return {
+    areaCode: "13000",
+    baseline: [],
+    choice: [],
+    compositeScore: 50,
+    confidence: { level: "high", reason: "テスト" },
+    rank: 1,
+    notes: [],
+    ...overrides,
+  };
+}
+
+describe("generateCityNarrative", () => {
+  it("1位の都市のナラティブを生成する", () => {
+    const result = makeResult({
+      cityName: "世田谷区",
+      compositeScore: 78.5,
+      rank: 1,
+      choice: [
+        { indicatorId: "population_total", score: 85 },
+        { indicatorId: "kids_ratio", score: 75 },
+        { indicatorId: "condo_price_median", score: 20 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 3);
+    expect(text).toContain("最も高い評価");
+    expect(text).toContain("総人口");
+    expect(text).toContain("0-14歳比率");
+    expect(text).toContain("強み");
+    expect(text).toContain("中古マンション価格");
+    expect(text).toContain("課題");
+  });
+
+  it("最下位の都市のナラティブを生成する", () => {
+    const result = makeResult({
+      cityName: "中野区",
+      compositeScore: 35.2,
+      rank: 3,
+      choice: [
+        { indicatorId: "population_total", score: 15 },
+        { indicatorId: "kids_ratio", score: 25 },
+        { indicatorId: "condo_price_median", score: 80 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 3);
+    expect(text).toContain("最も低い評価");
+    expect(text).toContain("中古マンション価格");
+    expect(text).toContain("強み");
+    expect(text).toContain("総人口");
+    expect(text).toContain("課題");
+  });
+
+  it("中間順位の都市のナラティブを生成する", () => {
+    const result = makeResult({
+      cityName: "渋谷区",
+      compositeScore: 55.0,
+      rank: 2,
+      choice: [
+        { indicatorId: "population_total", score: 50 },
+        { indicatorId: "kids_ratio", score: 90 },
+        { indicatorId: "condo_price_median", score: 40 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 3);
+    expect(text).toContain("2位");
+    expect(text).toContain("0-14歳比率");
+    expect(text).toContain("強み");
+  });
+
+  it("単独都市の場合のナラティブを生成する", () => {
+    const result = makeResult({
+      cityName: "世田谷区",
+      compositeScore: 60.0,
+      rank: 1,
+      choice: [
+        { indicatorId: "population_total", score: 80 },
+        { indicatorId: "kids_ratio", score: 50 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 1);
+    expect(text).toContain("世田谷区の総合スコアは60.0点です。");
+    expect(text).not.toContain("候補");
+  });
+
+  it("全指標が中立の場合", () => {
+    const result = makeResult({
+      cityName: "新宿区",
+      compositeScore: 50.0,
+      rank: 1,
+      choice: [
+        { indicatorId: "population_total", score: 50 },
+        { indicatorId: "kids_ratio", score: 55 },
+        { indicatorId: "condo_price_median", score: 45 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 2);
+    expect(text).toContain("平均的な水準");
+    expect(text).not.toContain("強み");
+    expect(text).not.toContain("課題");
+  });
+
+  it("信頼度Lowの場合に注記を含む", () => {
+    const result = makeResult({
+      cityName: "練馬区",
+      compositeScore: 45.0,
+      rank: 2,
+      confidence: { level: "low", reason: "データが古い" },
+      choice: [
+        { indicatorId: "population_total", score: 50 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 2);
+    expect(text).toContain("参考値としてご確認ください");
+    expect(text).toContain("欠損");
+  });
+
+  it("欠損指標がある場合に注記を含む（信頼度High）", () => {
+    const result = makeResult({
+      cityName: "板橋区",
+      compositeScore: 55.0,
+      rank: 1,
+      confidence: { level: "high", reason: "良好" },
+      choice: [
+        { indicatorId: "population_total", score: 60 },
+      ],
+    });
+    const text = generateCityNarrative(result, definitions, 2);
+    // definitions は3つだが choice は1つなので欠損2件
+    expect(text).toContain("2件の指標データが欠損");
+  });
+});
+
+describe("generateComparisonNarrative", () => {
+  it("僅差の場合のナラティブを生成する", () => {
+    const results: ReadonlyArray<CityScoreResult> = [
+      makeResult({
+        cityName: "世田谷区",
+        compositeScore: 52.0,
+        rank: 1,
+        choice: [
+          { indicatorId: "population_total", score: 80 },
+          { indicatorId: "kids_ratio", score: 30 },
+        ],
+      }),
+      makeResult({
+        cityName: "渋谷区",
+        compositeScore: 48.0,
+        rank: 2,
+        choice: [
+          { indicatorId: "population_total", score: 30 },
+          { indicatorId: "kids_ratio", score: 80 },
+        ],
+      }),
+    ];
+    const text = generateComparisonNarrative(results, definitions);
+    expect(text).toContain("僅差");
+    expect(text).toContain("世田谷区");
+    expect(text).toContain("渋谷区");
+  });
+
+  it("大差の場合のナラティブを生成する", () => {
+    const results: ReadonlyArray<CityScoreResult> = [
+      makeResult({
+        cityName: "世田谷区",
+        compositeScore: 85.0,
+        rank: 1,
+        choice: [
+          { indicatorId: "population_total", score: 100 },
+          { indicatorId: "kids_ratio", score: 90 },
+        ],
+      }),
+      makeResult({
+        cityName: "中野区",
+        compositeScore: 30.0,
+        rank: 2,
+        choice: [
+          { indicatorId: "population_total", score: 10 },
+          { indicatorId: "kids_ratio", score: 20 },
+        ],
+      }),
+    ];
+    const text = generateComparisonNarrative(results, definitions);
+    expect(text).toContain("大きな差");
+    expect(text).toContain("85.0");
+    expect(text).toContain("30.0");
+  });
+
+  it("全都市同スコアの場合", () => {
+    const results: ReadonlyArray<CityScoreResult> = [
+      makeResult({
+        cityName: "世田谷区",
+        compositeScore: 50.0,
+        rank: 1,
+        choice: [{ indicatorId: "population_total", score: 50 }],
+      }),
+      makeResult({
+        cityName: "渋谷区",
+        compositeScore: 50.0,
+        rank: 1,
+        choice: [{ indicatorId: "population_total", score: 50 }],
+      }),
+    ];
+    const text = generateComparisonNarrative(results, definitions);
+    expect(text).toContain("同等の評価");
+  });
+
+  it("1都市のみの場合は単独評価文を返す", () => {
+    const results: ReadonlyArray<CityScoreResult> = [
+      makeResult({
+        cityName: "世田谷区",
+        compositeScore: 60.0,
+        rank: 1,
+        choice: [{ indicatorId: "population_total", score: 80 }],
+      }),
+    ];
+    const text = generateComparisonNarrative(results, definitions);
+    expect(text).toContain("単独評価");
+    expect(text).not.toContain("優位");
+  });
+
+  it("トレードオフがある場合の比較文を生成する", () => {
+    const results: ReadonlyArray<CityScoreResult> = [
+      makeResult({
+        cityName: "世田谷区",
+        compositeScore: 65.0,
+        rank: 1,
+        choice: [
+          { indicatorId: "population_total", score: 90 },
+          { indicatorId: "kids_ratio", score: 80 },
+          { indicatorId: "condo_price_median", score: 30 },
+        ],
+      }),
+      makeResult({
+        cityName: "中野区",
+        compositeScore: 55.0,
+        rank: 2,
+        choice: [
+          { indicatorId: "population_total", score: 40 },
+          { indicatorId: "kids_ratio", score: 50 },
+          { indicatorId: "condo_price_median", score: 90 },
+        ],
+      }),
+    ];
+    const text = generateComparisonNarrative(results, definitions);
+    expect(text).toContain("世田谷区は総人口・0-14歳比率で優位");
+    expect(text).toContain("中野区は中古マンション価格（中央値）で優位");
+    expect(text).toContain("優先する観点によって選択が分かれます");
+  });
+
+  it("全指標で同一都市がリードしている場合", () => {
+    const results: ReadonlyArray<CityScoreResult> = [
+      makeResult({
+        cityName: "世田谷区",
+        compositeScore: 80.0,
+        rank: 1,
+        choice: [
+          { indicatorId: "population_total", score: 90 },
+          { indicatorId: "kids_ratio", score: 85 },
+        ],
+      }),
+      makeResult({
+        cityName: "中野区",
+        compositeScore: 30.0,
+        rank: 2,
+        choice: [
+          { indicatorId: "population_total", score: 10 },
+          { indicatorId: "kids_ratio", score: 15 },
+        ],
+      }),
+    ];
+    const text = generateComparisonNarrative(results, definitions);
+    expect(text).toContain("世田谷区は全ての指標で候補内最高値を記録しています");
+  });
+});

--- a/tests/report/templates.test.ts
+++ b/tests/report/templates.test.ts
@@ -91,7 +91,7 @@ describe("renderCover", () => {
 
 describe("renderSummary", () => {
   it("サマリHTMLを生成する", () => {
-    const html = renderSummary({ results: sampleResults, presetLabel: "子育て重視" });
+    const html = renderSummary({ results: sampleResults, presetLabel: "子育て重視", definitions });
     expect(html).toContain("結論サマリ");
     expect(html).toContain("新宿区");
     expect(html).toContain("渋谷区");
@@ -114,6 +114,7 @@ describe("renderCityDetail", () => {
       result: sampleResults[0],
       definition: definitions,
       rawRow: rawRows[0],
+      totalCities: 2,
     });
     expect(html).toContain("新宿区");
     expect(html).toContain("13104");
@@ -147,6 +148,7 @@ describe("renderCityDetail", () => {
       result: resultWithPrice,
       definition: defsWithPrice,
       rawRow: rawRowWithPrice,
+      totalCities: 2,
     });
     expect(html).toContain("中古マンション価格");
     expect(html).toContain("4,000");


### PR DESCRIPTION
## Summary

各市区町村の詳細ページと比較ページに、データから自動生成された評価文（ナラティブ）を追加しました。データテーブルだけでなく、強み・弱み分析と候補間のトレードオフを日本語で提示することで、レポートの実用性を大幅に向上させています。

## Changes

- **src/report/narrative.ts** (新規): ルールベースのナラティブ生成エンジン
  - `generateCityNarrative()`: 総合スコア、Choice Score ≥70 の指標を「強み」、≤30 を「弱み」として自動分類
  - `generateComparisonNarrative()`: 1位の結論（僅差/大差判定）+ 指標ごとのリーダー特定によるトレードオフ分析
  
- **テンプレート統合**:
  - city-detail.ts: 指標表の下に「評価コメント」セクション
  - summary.ts: ランキング表の下に「総合評価」セクション
  - styles.ts: `.narrative` クラス（左ボーダー付きカード風）
  
- **テスト**: 13ケース追加（1位/最下位/単独/全中立/僅差/大差/トレードオフなど）

## Test Plan

- [x] `npm test` — 全406テスト通過（新規13テスト含む）
- [x] `npm run build` — TypeScript型チェック成功
- [x] XSSエスケープ検証済み（escapeHtml適用）
- [x] ナラティブ生成ロジック（純粋関数）単体テスト完全カバー