### PR TITLE
fix: 犯罪統計データの取得失敗を修正

### DIFF
--- a/src/estat/meta.ts
+++ b/src/estat/meta.ts
@@ -521,7 +521,7 @@ export function extractDataValues(data: any): DataValue[] {
         area = textFrom(value);
       } else if (normalizedKey === "time") {
         time = textFrom(value);
-      } else if (normalizedKey.startsWith("cat")) {
+      } else if (normalizedKey.startsWith("cat") || normalizedKey === "tab") {
         cats[normalizedKey] = textFrom(value);
       }
     }


### PR DESCRIPTION
## 概要

e-Stat「社会・人口統計体系」テーブル（statsDataId: 0000020211）から犯罪統計データが一度も取得できていなかった問題を修正しました。

## 原因

テーブルの指標が `tab`（表章項目）に格納されているのに対し、コードは `cat*` プレフィックスのクラスのみを検索していたため、指標検出に失敗していました。

## 修正内容

1. **resolveIndicatorClass**: `tab` クラスの指標も検出するよう対応
2. **buildCrimeData**: `resolveDefaultFilters` を適用し、余分な分類（男女別、実数/比率等）をデフォルト値でフィルタ（メインレポートと同じパターン）
3. **extractDataValues**: `@tab` 属性も `DataValue.cats` に格納するよう修正
4. **テスト**: tab クラスのテストケース 2 件追加（自動検出 + フィルタ適用検証）

## 検証

- 全 395 テスト通過（回帰なし）
- TypeScript 型チェック: 問題なし
- コードレビュー: 承認可能（警告対応済み）

実際の API 動作確認には `.env` に `ESTAT_APP_ID` の設定が必要です。

設定後に以下のコマンドで検証できます:
```bash
npm run dev -- report --cities "新宿区,渋谷区"
npm run dev -- report --cities "安城市,岡崎市,知立市,豊田市"
```