### PR TITLE
feat: PDFレポートのデザインをリニューアル

### DIFF
--- a/src/report/templates/charts/bar.ts
+++ b/src/report/templates/charts/bar.ts
@@ -1,0 +1,83 @@
+/** 水平バーチャート SVG 生成 */
+
+export interface BarChartItem {
+  readonly label: string;
+  readonly value: number;
+  readonly color: string;
+}
+
+export interface BarChartOptions {
+  readonly width?: number;
+  readonly barHeight?: number;
+  readonly gap?: number;
+  readonly showValues?: boolean;
+  readonly labelWidth?: number;
+}
+
+const DEFAULT_WIDTH = 480;
+const DEFAULT_BAR_HEIGHT = 22;
+const DEFAULT_GAP = 10;
+const DEFAULT_LABEL_WIDTH = 100;
+
+/** 水平バーチャートSVGを生成 */
+export function renderHorizontalBarChart(
+  items: ReadonlyArray<BarChartItem>,
+  options: BarChartOptions = {},
+): string {
+  const width = options.width ?? DEFAULT_WIDTH;
+  const barHeight = options.barHeight ?? DEFAULT_BAR_HEIGHT;
+  const gap = options.gap ?? DEFAULT_GAP;
+  const showValues = options.showValues ?? true;
+  const labelWidth = options.labelWidth ?? DEFAULT_LABEL_WIDTH;
+
+  if (items.length === 0) {
+    return "";
+  }
+
+  const barAreaWidth = width - labelWidth - 60;
+  const totalHeight = items.length * (barHeight + gap) + 8;
+
+  const parts: string[] = [];
+  parts.push(`<svg viewBox="0 0 ${width} ${totalHeight}" width="${width}" height="${totalHeight}" xmlns="http://www.w3.org/2000/svg">`);
+
+  // 背景グリッド
+  for (const pct of [25, 50, 75, 100]) {
+    const x = labelWidth + (barAreaWidth * pct) / 100;
+    parts.push(`  <line x1="${x.toFixed(1)}" y1="0" x2="${x.toFixed(1)}" y2="${totalHeight}" stroke="#e2e8f0" stroke-width="0.5" stroke-dasharray="3,3"/>`);
+  }
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    const y = i * (barHeight + gap) + 4;
+    const barW = Math.max(0, (barAreaWidth * Math.min(item.value, 100)) / 100);
+
+    // ラベル
+    parts.push(`  <text x="${labelWidth - 8}" y="${y + barHeight / 2 + 1}" text-anchor="end" dominant-baseline="central" font-size="12" font-weight="500" fill="#1e293b">${escapeXml(item.label)}</text>`);
+
+    // バー背景
+    parts.push(`  <rect x="${labelWidth}" y="${y}" width="${barAreaWidth}" height="${barHeight}" rx="${barHeight / 2}" fill="#f1f5f9"/>`);
+
+    // バー本体
+    if (barW > 0) {
+      parts.push(`  <rect x="${labelWidth}" y="${y}" width="${barW.toFixed(1)}" height="${barHeight}" rx="${barHeight / 2}" fill="${item.color}" opacity="0.85"/>`);
+    }
+
+    // スコア値
+    if (showValues) {
+      const textX = labelWidth + barW + 8;
+      parts.push(`  <text x="${textX.toFixed(1)}" y="${y + barHeight / 2 + 1}" dominant-baseline="central" font-size="12" font-weight="700" fill="${item.color}">${item.value.toFixed(1)}</text>`);
+    }
+  }
+
+  parts.push("</svg>");
+  return parts.join("\n");
+}
+
+/** SVG用XMLエスケープ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/report/templates/charts/cityscape.ts
+++ b/src/report/templates/charts/cityscape.ts
@@ -1,0 +1,85 @@
+/** カバーページ用の街並みシルエットSVG */
+
+/** 街並みシルエットSVGを生成（パステルカラーの装飾） */
+export function renderCityscapeSvg(): string {
+  return `<svg viewBox="0 0 600 120" width="100%" height="120" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMax slice">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#d1fae5"/>
+      <stop offset="50%" stop-color="#e0f2fe"/>
+      <stop offset="100%" stop-color="#ede9fe"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="600" height="120" fill="url(#sky)" rx="0"/>
+
+  <!-- 雲 -->
+  <ellipse cx="90" cy="30" rx="30" ry="12" fill="white" opacity="0.6"/>
+  <ellipse cx="110" cy="26" rx="22" ry="10" fill="white" opacity="0.5"/>
+  <ellipse cx="450" cy="22" rx="26" ry="10" fill="white" opacity="0.5"/>
+  <ellipse cx="470" cy="18" rx="20" ry="8" fill="white" opacity="0.4"/>
+
+  <!-- 木（左） -->
+  <rect x="40" y="75" width="6" height="25" rx="2" fill="#92400e" opacity="0.5"/>
+  <ellipse cx="43" cy="68" rx="16" ry="18" fill="#10b981" opacity="0.4"/>
+  <rect x="80" y="80" width="5" height="20" rx="2" fill="#92400e" opacity="0.4"/>
+  <ellipse cx="82" cy="74" rx="12" ry="14" fill="#10b981" opacity="0.35"/>
+
+  <!-- ビル群（左） -->
+  <rect x="110" y="50" width="28" height="50" rx="2" fill="#0ea5e9" opacity="0.25"/>
+  <rect x="115" y="56" width="6" height="6" rx="1" fill="white" opacity="0.5"/>
+  <rect x="125" y="56" width="6" height="6" rx="1" fill="white" opacity="0.5"/>
+  <rect x="115" y="66" width="6" height="6" rx="1" fill="white" opacity="0.5"/>
+  <rect x="125" y="66" width="6" height="6" rx="1" fill="white" opacity="0.5"/>
+
+  <rect x="145" y="38" width="24" height="62" rx="2" fill="#8b5cf6" opacity="0.2"/>
+  <rect x="150" y="44" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="158" y="44" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="150" y="54" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="158" y="54" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+
+  <rect x="176" y="55" width="30" height="45" rx="2" fill="#f43f5e" opacity="0.18"/>
+  <rect x="182" y="62" width="6" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="192" y="62" width="6" height="5" rx="1" fill="white" opacity="0.4"/>
+
+  <!-- 中央の家・マンション -->
+  <rect x="230" y="60" width="34" height="40" rx="3" fill="#10b981" opacity="0.3"/>
+  <rect x="236" y="66" width="7" height="7" rx="1" fill="white" opacity="0.5"/>
+  <rect x="249" y="66" width="7" height="7" rx="1" fill="white" opacity="0.5"/>
+  <rect x="241" y="82" width="12" height="18" rx="2" fill="#065f46" opacity="0.3"/>
+
+  <rect x="275" y="45" width="26" height="55" rx="2" fill="#0ea5e9" opacity="0.22"/>
+  <rect x="280" y="50" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="289" y="50" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="280" y="60" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="289" y="60" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+
+  <rect x="310" y="36" width="22" height="64" rx="2" fill="#f59e0b" opacity="0.2"/>
+  <rect x="314" y="42" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="314" y="52" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+
+  <!-- ビル群（右） -->
+  <rect x="345" y="52" width="32" height="48" rx="2" fill="#8b5cf6" opacity="0.22"/>
+  <rect x="350" y="58" width="6" height="6" rx="1" fill="white" opacity="0.45"/>
+  <rect x="362" y="58" width="6" height="6" rx="1" fill="white" opacity="0.45"/>
+  <rect x="350" y="68" width="6" height="6" rx="1" fill="white" opacity="0.45"/>
+  <rect x="362" y="68" width="6" height="6" rx="1" fill="white" opacity="0.45"/>
+
+  <rect x="385" y="42" width="24" height="58" rx="2" fill="#f43f5e" opacity="0.2"/>
+  <rect x="390" y="48" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+  <rect x="398" y="48" width="5" height="5" rx="1" fill="white" opacity="0.4"/>
+
+  <rect x="418" y="56" width="28" height="44" rx="2" fill="#10b981" opacity="0.25"/>
+  <rect x="423" y="62" width="6" height="6" rx="1" fill="white" opacity="0.4"/>
+  <rect x="433" y="62" width="6" height="6" rx="1" fill="white" opacity="0.4"/>
+
+  <!-- 木（右） -->
+  <rect x="470" y="78" width="5" height="22" rx="2" fill="#92400e" opacity="0.45"/>
+  <ellipse cx="472" cy="72" rx="14" ry="16" fill="#10b981" opacity="0.38"/>
+  <rect x="510" y="82" width="5" height="18" rx="2" fill="#92400e" opacity="0.4"/>
+  <ellipse cx="512" cy="76" rx="11" ry="13" fill="#10b981" opacity="0.3"/>
+
+  <!-- 地面 -->
+  <rect x="0" y="100" width="600" height="20" fill="#10b981" opacity="0.12" rx="0"/>
+</svg>`;
+}

--- a/src/report/templates/charts/colors.ts
+++ b/src/report/templates/charts/colors.ts
@@ -1,0 +1,93 @@
+import { IndicatorCategory, IndicatorDefinition } from "../../../scoring/types";
+import { escapeHtml } from "../../../utils";
+
+/** カテゴリカラーの定義 */
+export interface CategoryColor {
+  readonly primary: string;
+  readonly light: string;
+  readonly dark: string;
+  readonly emoji: string;
+  readonly label: string;
+}
+
+/** カテゴリごとのカラー定義（子育て世帯向けの温かいパレット） */
+export const CATEGORY_COLORS: Readonly<Record<IndicatorCategory, CategoryColor>> = {
+  childcare: {
+    primary: "#10b981",
+    light: "#d1fae5",
+    dark: "#065f46",
+    emoji: "\u{1F476}",
+    label: "\u5b50\u80b2\u3066",
+  },
+  price: {
+    primary: "#0ea5e9",
+    light: "#e0f2fe",
+    dark: "#075985",
+    emoji: "\u{1F3e0}",
+    label: "\u4f4f\u5b85\u4fa1\u683c",
+  },
+  safety: {
+    primary: "#f43f5e",
+    light: "#ffe4e6",
+    dark: "#9f1239",
+    emoji: "\u{1F6e1}\uFE0F",
+    label: "\u5b89\u5168",
+  },
+  disaster: {
+    primary: "#8b5cf6",
+    light: "#ede9fe",
+    dark: "#5b21b6",
+    emoji: "\u{1F30a}",
+    label: "\u707d\u5bb3",
+  },
+  transport: {
+    primary: "#f59e0b",
+    light: "#fef3c7",
+    dark: "#92400e",
+    emoji: "\u{1F683}",
+    label: "\u4ea4\u901a",
+  },
+};
+
+/** 都市ごとのチャートカラー（最大7都市対応） */
+export const CITY_COLORS: ReadonlyArray<string> = [
+  "#0ea5e9",
+  "#f43f5e",
+  "#10b981",
+  "#f59e0b",
+  "#8b5cf6",
+  "#06b6d4",
+  "#ec4899",
+];
+
+/** カテゴリカラーを取得 */
+export function getCategoryColor(category: IndicatorCategory): CategoryColor {
+  return CATEGORY_COLORS[category];
+}
+
+/** 指標IDからカテゴリを解決 */
+export function getCategoryForIndicator(
+  indicatorId: string,
+  definitions: ReadonlyArray<IndicatorDefinition>,
+): IndicatorCategory | undefined {
+  return definitions.find((d) => d.id === indicatorId)?.category;
+}
+
+/** 都市インデックスからチャートカラーを取得 */
+export function getCityColor(index: number): string {
+  return CITY_COLORS[index % CITY_COLORS.length];
+}
+
+/** カテゴリバッジHTMLを生成 */
+export function renderCategoryBadge(category: IndicatorCategory): string {
+  const c = CATEGORY_COLORS[category];
+  return `<span class="category-badge" style="background:${c.light};color:${c.dark};border:1px solid ${c.primary}33;">${c.emoji} ${escapeHtml(c.label)}</span>`;
+}
+
+/** 全カテゴリの凡例バッジを横並びで生成 */
+export function renderCategoryLegend(
+  categories: ReadonlyArray<IndicatorCategory>,
+): string {
+  const badges = categories.map((cat) => renderCategoryBadge(cat)).join("");
+  return `<div style="display:flex;justify-content:center;gap:10px;flex-wrap:wrap;">${badges}</div>`;
+}

--- a/src/report/templates/charts/gauge.ts
+++ b/src/report/templates/charts/gauge.ts
@@ -1,0 +1,94 @@
+/** 半円スコアゲージ SVG 生成 */
+
+export interface GaugeData {
+  readonly score: number;
+  readonly label?: string;
+  readonly rank?: number;
+  readonly totalCities?: number;
+}
+
+export interface GaugeOptions {
+  readonly width?: number;
+  readonly height?: number;
+  readonly strokeWidth?: number;
+}
+
+const DEFAULT_WIDTH = 200;
+const DEFAULT_HEIGHT = 130;
+const DEFAULT_STROKE_WIDTH = 16;
+
+/** スコアに応じたグラデーション色を取得 */
+function scoreColor(score: number): string {
+  if (score >= 70) return "#10b981";
+  if (score >= 40) return "#f59e0b";
+  return "#f43f5e";
+}
+
+/** 半円ゲージSVGを生成 */
+export function renderScoreGauge(
+  data: GaugeData,
+  options: GaugeOptions = {},
+): string {
+  const width = options.width ?? DEFAULT_WIDTH;
+  const height = options.height ?? DEFAULT_HEIGHT;
+  const strokeW = options.strokeWidth ?? DEFAULT_STROKE_WIDTH;
+  const score = Math.max(0, Math.min(100, data.score));
+
+  const cx = width / 2;
+  const cy = height - 20;
+  const radius = Math.min(cx, cy) - strokeW / 2 - 4;
+
+  // 半円アーク（左端180度 → 右端0度）
+  const circumference = Math.PI * radius;
+  const filledLength = (circumference * score) / 100;
+  const color = scoreColor(score);
+
+  // アークパス（半円）
+  const startX = cx - radius;
+  const startY = cy;
+  const endX = cx + radius;
+  const endY = cy;
+
+  const parts: string[] = [];
+  parts.push(`<svg viewBox="0 0 ${width} ${height}" width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">`);
+
+  // 背景グラデーション定義
+  parts.push(`  <defs>`);
+  parts.push(`    <linearGradient id="gauge-bg" x1="0" y1="0" x2="1" y2="0">`);
+  parts.push(`      <stop offset="0%" stop-color="#f43f5e" stop-opacity="0.15"/>`);
+  parts.push(`      <stop offset="50%" stop-color="#f59e0b" stop-opacity="0.15"/>`);
+  parts.push(`      <stop offset="100%" stop-color="#10b981" stop-opacity="0.15"/>`);
+  parts.push(`    </linearGradient>`);
+  parts.push(`  </defs>`);
+
+  // 背景アーク
+  parts.push(`  <path d="M ${startX} ${startY} A ${radius} ${radius} 0 0 1 ${endX} ${endY}" fill="none" stroke="url(#gauge-bg)" stroke-width="${strokeW}" stroke-linecap="round"/>`);
+
+  // スコアアーク
+  parts.push(`  <path d="M ${startX} ${startY} A ${radius} ${radius} 0 0 1 ${endX} ${endY}" fill="none" stroke="${color}" stroke-width="${strokeW}" stroke-linecap="round" stroke-dasharray="${circumference.toFixed(1)}" stroke-dashoffset="${(circumference - filledLength).toFixed(1)}"/>`);
+
+  // スコア数値
+  parts.push(`  <text x="${cx}" y="${cy - 16}" text-anchor="middle" dominant-baseline="auto" font-size="36" font-weight="800" fill="${color}">${score.toFixed(1)}</text>`);
+
+  // ラベル
+  if (data.label) {
+    parts.push(`  <text x="${cx}" y="${cy - 2}" text-anchor="middle" font-size="11" fill="#64748b">${escapeXml(data.label)}</text>`);
+  }
+
+  // 順位
+  if (data.rank != null && data.totalCities != null) {
+    parts.push(`  <text x="${cx}" y="${cy + 16}" text-anchor="middle" font-size="13" font-weight="600" fill="#1e293b">${data.rank}\u4f4d / ${data.totalCities}\u5e02\u533a\u753a\u6751</text>`);
+  }
+
+  parts.push("</svg>");
+  return parts.join("\n");
+}
+
+/** SVG用XMLエスケープ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/report/templates/charts/radar.ts
+++ b/src/report/templates/charts/radar.ts
@@ -1,0 +1,158 @@
+/** レーダーチャート SVG 生成 */
+
+export interface RadarDataset {
+  readonly name: string;
+  readonly values: ReadonlyArray<number>;
+  readonly color: string;
+}
+
+export interface RadarChartData {
+  readonly labels: ReadonlyArray<string>;
+  readonly datasets: ReadonlyArray<RadarDataset>;
+  readonly categoryColors?: ReadonlyArray<string>;
+}
+
+export interface RadarChartOptions {
+  readonly size?: number;
+  readonly levels?: number;
+  readonly showLabels?: boolean;
+  readonly showLegend?: boolean;
+}
+
+const DEFAULT_SIZE = 360;
+const DEFAULT_LEVELS = 5;
+
+/** 角度計算（上向き開始、時計回り） */
+function angle(index: number, total: number): number {
+  return (Math.PI * 2 * index) / total - Math.PI / 2;
+}
+
+/** 極座標→直交座標 */
+function polarToXY(
+  cx: number,
+  cy: number,
+  radius: number,
+  index: number,
+  total: number,
+): { readonly x: number; readonly y: number } {
+  const a = angle(index, total);
+  return {
+    x: cx + radius * Math.cos(a),
+    y: cy + radius * Math.sin(a),
+  };
+}
+
+/** 多角形のポイント文字列を生成 */
+function polygonPoints(
+  cx: number,
+  cy: number,
+  radius: number,
+  count: number,
+): string {
+  return Array.from({ length: count })
+    .map((_, i) => {
+      const p = polarToXY(cx, cy, radius, i, count);
+      return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+    })
+    .join(" ");
+}
+
+/** レーダーチャートSVGを生成 */
+export function renderRadarChart(
+  data: RadarChartData,
+  options: RadarChartOptions = {},
+): string {
+  const size = options.size ?? DEFAULT_SIZE;
+  const levels = options.levels ?? DEFAULT_LEVELS;
+  const showLabels = options.showLabels ?? true;
+  const showLegend = options.showLegend ?? true;
+  const count = data.labels.length;
+
+  if (count < 3) {
+    return "";
+  }
+
+  const cx = size / 2;
+  const cy = size / 2;
+  const maxR = size * 0.35;
+  const legendHeight = showLegend ? 30 : 0;
+  const totalHeight = size + legendHeight;
+
+  const parts: string[] = [];
+
+  parts.push(`<svg viewBox="0 0 ${size} ${totalHeight}" width="${size}" height="${totalHeight}" xmlns="http://www.w3.org/2000/svg">`);
+
+  // 同心多角形グリッド
+  for (let lv = 1; lv <= levels; lv++) {
+    const r = (maxR * lv) / levels;
+    const pts = polygonPoints(cx, cy, r, count);
+    const opacity = lv === levels ? 0.3 : 0.15;
+    parts.push(`  <polygon points="${pts}" fill="none" stroke="#94a3b8" stroke-width="0.8" opacity="${opacity}"/>`);
+  }
+
+  // 軸線
+  for (let i = 0; i < count; i++) {
+    const p = polarToXY(cx, cy, maxR, i, count);
+    parts.push(`  <line x1="${cx}" y1="${cy}" x2="${p.x.toFixed(1)}" y2="${p.y.toFixed(1)}" stroke="#cbd5e1" stroke-width="0.6"/>`);
+  }
+
+  // データポリゴン
+  for (const ds of data.datasets) {
+    const pts = ds.values
+      .map((v, i) => {
+        const r = (maxR * Math.min(v, 100)) / 100;
+        const p = polarToXY(cx, cy, r, i, count);
+        return `${p.x.toFixed(1)},${p.y.toFixed(1)}`;
+      })
+      .join(" ");
+    parts.push(`  <polygon points="${pts}" fill="${ds.color}" fill-opacity="0.15" stroke="${ds.color}" stroke-width="2.5"/>`);
+
+    // データドット
+    for (let i = 0; i < ds.values.length; i++) {
+      const r = (maxR * Math.min(ds.values[i], 100)) / 100;
+      const p = polarToXY(cx, cy, r, i, count);
+      parts.push(`  <circle cx="${p.x.toFixed(1)}" cy="${p.y.toFixed(1)}" r="4" fill="${ds.color}"/>`);
+    }
+  }
+
+  // 軸ラベル
+  if (showLabels) {
+    const labelR = maxR + 24;
+    for (let i = 0; i < count; i++) {
+      const p = polarToXY(cx, cy, labelR, i, count);
+      const a = angle(i, count);
+      const anchor =
+        Math.abs(Math.cos(a)) < 0.1 ? "middle" : Math.cos(a) > 0 ? "start" : "end";
+      const catColor = data.categoryColors?.[i] ?? "#1e293b";
+      parts.push(`  <text x="${p.x.toFixed(1)}" y="${p.y.toFixed(1)}" text-anchor="${anchor}" dominant-baseline="central" font-size="12" font-weight="600" fill="${catColor}">${escapeXml(data.labels[i])}</text>`);
+    }
+  }
+
+  // 凡例
+  if (showLegend && data.datasets.length > 0) {
+    const legendY = size + 8;
+    const totalWidth = data.datasets.reduce(
+      (sum, ds) => sum + ds.name.length * 13 + 28,
+      0,
+    );
+    let legendX = Math.max(8, (size - totalWidth) / 2);
+
+    for (const ds of data.datasets) {
+      parts.push(`  <rect x="${legendX}" y="${legendY}" width="14" height="14" rx="3" fill="${ds.color}"/>`);
+      parts.push(`  <text x="${legendX + 18}" y="${legendY + 11}" font-size="12" fill="#1e293b">${escapeXml(ds.name)}</text>`);
+      legendX += ds.name.length * 13 + 28;
+    }
+  }
+
+  parts.push("</svg>");
+  return parts.join("\n");
+}
+
+/** SVG用XMLエスケープ */
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/src/report/templates/city-detail.ts
+++ b/src/report/templates/city-detail.ts
@@ -1,7 +1,14 @@
-import { CityScoreResult, IndicatorDefinition, ConfidenceLevel } from "../../scoring/types";
+import {
+  CityScoreResult,
+  IndicatorCategory,
+  IndicatorDefinition,
+  ConfidenceLevel,
+} from "../../scoring/types";
 import { escapeHtml } from "../../utils";
 import { ReportRow } from "../../types";
 import { generateCityNarrative } from "../narrative";
+import { renderScoreGauge } from "./charts/gauge";
+import { CATEGORY_COLORS } from "./charts/colors";
 
 export interface CityDetailModel {
   readonly result: CityScoreResult;
@@ -24,14 +31,18 @@ function numberFormat(value: number): string {
 }
 
 /** 指標IDからReportRowの実値を取得するマッピング */
-function getRawValue(indicatorId: string, rawRow: ReportRow): number | null | undefined {
+function getRawValue(
+  indicatorId: string,
+  rawRow: ReportRow,
+): number | null | undefined {
   const mapping: Record<string, () => number | null | undefined> = {
     population_total: () => rawRow.total,
     kids_ratio: () => rawRow.ratio,
     condo_price_median: () => rawRow.condoPriceMedian,
     crime_rate: () => rawRow.crimeRate,
     flood_risk: () => {
-      if (rawRow.floodRisk == null && rawRow.landslideRisk == null) return undefined;
+      if (rawRow.floodRisk == null && rawRow.landslideRisk == null)
+        return undefined;
       return (rawRow.floodRisk ? 1 : 0) + (rawRow.landslideRisk ? 1 : 0);
     },
     evacuation_sites: () => rawRow.evacuationSiteCount,
@@ -39,97 +50,167 @@ function getRawValue(indicatorId: string, rawRow: ReportRow): number | null | un
   return mapping[indicatorId]?.() ?? undefined;
 }
 
-function formatRawValue(raw: number | null | undefined, def: IndicatorDefinition): string {
+function formatRawValue(
+  raw: number | null | undefined,
+  def: IndicatorDefinition,
+): string {
   if (raw === null || raw === undefined) {
     return "-";
   }
   return def.precision === 0 ? numberFormat(raw) : raw.toFixed(def.precision);
 }
 
-/** 価格のQ25-Q75レンジ行（存在する場合のみ） */
-function renderPriceRange(rawRow: ReportRow): string {
+/** 価格レンジ情報のHTML（カード内表示用） */
+function renderPriceRangeCard(rawRow: ReportRow): string {
   const q25 = rawRow.condoPriceQ25;
   const q75 = rawRow.condoPriceQ75;
   const count = rawRow.condoPriceCount;
   if (q25 == null || q75 == null) {
     return "";
   }
-  const countDisplay = count != null ? `（取引件数: ${numberFormat(count)}件）` : "";
+  const countDisplay =
+    count != null
+      ? `<span class="note">\uff08\u53d6\u5f15\u4ef6\u6570: ${numberFormat(count)}\u4ef6\uff09</span>`
+      : "";
   const affordabilityLine =
     rawRow.affordabilityRate != null
-      ? `
-        <tr>
-          <td>├ 予算内取引割合</td>
-          <td class="num">${rawRow.affordabilityRate.toFixed(1)}%</td>
-          <td class="num">-</td>
-          <td class="num">-</td>
-        </tr>`
+      ? `<div style="margin-top:6px;font-size:12px;">\u4e88\u7b97\u5185\u53d6\u5f15\u5272\u5408: <strong>${rawRow.affordabilityRate.toFixed(1)}%</strong></div>`
       : "";
+
   return `
-        <tr>
-          <td>├ 価格レンジ (Q25-Q75)</td>
-          <td class="num">${numberFormat(q25)} 〜 ${numberFormat(q75)} 万円${countDisplay}</td>
-          <td class="num">-</td>
-          <td class="num">-</td>
-        </tr>${affordabilityLine}`;
+    <div style="margin-top:8px;padding:8px 12px;background:#f8fafc;border-radius:8px;font-size:12px;">
+      \u4fa1\u683c\u30ec\u30f3\u30b8 (Q25-Q75): <strong>${numberFormat(q25)} \u301c ${numberFormat(q75)} \u4e07\u5186</strong> ${countDisplay}
+      ${affordabilityLine}
+    </div>`;
+}
+
+/** 指標をカテゴリ別にグループ化 */
+function groupByCategory(
+  definitions: ReadonlyArray<IndicatorDefinition>,
+): ReadonlyArray<{
+  readonly category: IndicatorCategory;
+  readonly defs: ReadonlyArray<IndicatorDefinition>;
+}> {
+  const seen = new Set<IndicatorCategory>();
+  const groups: Array<{
+    readonly category: IndicatorCategory;
+    readonly defs: ReadonlyArray<IndicatorDefinition>;
+  }> = [];
+
+  for (const def of definitions) {
+    if (!seen.has(def.category)) {
+      seen.add(def.category);
+      groups.push({
+        category: def.category,
+        defs: definitions.filter((d) => d.category === def.category),
+      });
+    }
+  }
+  return groups;
 }
 
 export function renderCityDetail(model: CityDetailModel): string {
   const { result, rawRow } = model;
 
-  const indicatorRows = model.definition
-    .map((def) => {
-      const cs = result.choice.find((c) => c.indicatorId === def.id);
-      const bs = result.baseline.find((b) => b.indicatorId === def.id);
-      const raw = getRawValue(def.id, rawRow);
-      const rawDisplay = formatRawValue(raw, def);
-      const priceRange = def.id === "condo_price_median" ? renderPriceRange(rawRow) : "";
+  // スコアゲージ
+  const gauge = renderScoreGauge({
+    score: result.compositeScore,
+    label: "\u7dcf\u5408\u30b9\u30b3\u30a2",
+    rank: result.rank,
+    totalCities: model.totalCities,
+  });
+
+  // カテゴリ別カード
+  const groups = groupByCategory(model.definition);
+  const categoryCards = groups
+    .map((group) => {
+      const catColor = CATEGORY_COLORS[group.category];
+
+      const indicators = group.defs
+        .map((def) => {
+          const cs = result.choice.find((c) => c.indicatorId === def.id);
+          const bs = result.baseline.find((b) => b.indicatorId === def.id);
+          const raw = getRawValue(def.id, rawRow);
+          const rawDisplay = formatRawValue(raw, def);
+          const score = cs?.score ?? 0;
+          const scoreColor =
+            score >= 70 ? "#10b981" : score >= 40 ? "#f59e0b" : "#f43f5e";
+          const priceRange =
+            def.id === "condo_price_median"
+              ? renderPriceRangeCard(rawRow)
+              : "";
+
+          return `
+          <div style="display:flex;justify-content:space-between;align-items:flex-start;padding:10px 0;${group.defs.indexOf(def) < group.defs.length - 1 ? "border-bottom:1px solid #f1f5f9;" : ""}">
+            <div style="flex:1;">
+              <div style="font-weight:600;font-size:13px;color:#1e293b;">${escapeHtml(def.label)}</div>
+              <div style="font-size:18px;font-weight:700;color:#1e293b;margin-top:2px;">${rawDisplay} <span style="font-size:12px;color:#64748b;">${escapeHtml(def.unit)}</span></div>
+              ${priceRange}
+            </div>
+            <div style="text-align:right;min-width:80px;">
+              <div style="font-size:20px;font-weight:800;color:${scoreColor};">${cs ? cs.score.toFixed(1) : "-"}</div>
+              <div class="note">\u30b9\u30b3\u30a2</div>
+              ${bs ? `<div class="note" style="margin-top:2px;">${bs.percentile.toFixed(1)}%</div>` : ""}
+            </div>
+          </div>`;
+        })
+        .join("");
+
+      // ミニスコアバー（カテゴリ平均）
+      const catScores = group.defs
+        .map((d) => result.choice.find((c) => c.indicatorId === d.id)?.score)
+        .filter((s): s is number => s !== undefined);
+      const catAvg =
+        catScores.length > 0
+          ? catScores.reduce((a, b) => a + b, 0) / catScores.length
+          : 0;
 
       return `
-        <tr>
-          <td>${escapeHtml(def.label)}</td>
-          <td class="num">${rawDisplay} ${escapeHtml(def.unit)}</td>
-          <td class="num">${cs ? cs.score.toFixed(1) : "-"}</td>
-          <td class="num">${bs ? `${bs.percentile.toFixed(1)}%` : "-"}</td>
-        </tr>${priceRange}`;
+        <div class="score-card" style="border-left:4px solid ${catColor.primary};">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
+            <div style="display:flex;align-items:center;gap:8px;">
+              <span style="font-size:18px;">${catColor.emoji}</span>
+              <span style="font-weight:700;font-size:15px;color:${catColor.dark};">${escapeHtml(catColor.label)}</span>
+            </div>
+            <div style="font-size:13px;color:#64748b;">\u5e73\u5747 <strong style="color:${catColor.primary};">${catAvg.toFixed(1)}</strong></div>
+          </div>
+          <div class="score-bar" style="height:6px;margin-bottom:12px;">
+            <div class="score-bar-fill" style="width:${catAvg}%;background:${catColor.primary};"></div>
+          </div>
+          ${indicators}
+        </div>`;
     })
     .join("\n");
 
   const notesList =
     result.notes.length > 0
       ? result.notes.map((n) => `<li>${escapeHtml(n)}</li>`).join("")
-      : "<li>特記事項なし</li>";
+      : "<li>\u7279\u8a18\u4e8b\u9805\u306a\u3057</li>";
 
   return `
     <section class="page">
-      <h2>${escapeHtml(result.cityName)}（${escapeHtml(result.areaCode)}）</h2>
-      <p class="meta">
-        総合スコア: <strong>${result.compositeScore.toFixed(1)}</strong> / 100
-        &nbsp;|&nbsp; 順位: <strong>${result.rank}位</strong>
-        &nbsp;|&nbsp; 信頼度: <span class="badge badge-${result.confidence.level}">${confidenceLabel(result.confidence.level)}</span>
-      </p>
+      <h2>${escapeHtml(result.cityName)}\uff08${escapeHtml(result.areaCode)}\uff09</h2>
 
-      <h3>指標詳細</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>指標</th>
-            <th>実値</th>
-            <th>候補内スコア</th>
-            <th>パーセンタイル</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${indicatorRows}
-        </tbody>
-      </table>
+      <div style="display:flex;align-items:center;gap:24px;margin-bottom:20px;flex-wrap:wrap;">
+        <div class="chart-container" style="margin:0;">${gauge}</div>
+        <div>
+          <p class="meta" style="margin-bottom:8px;">
+            \u7dcf\u5408\u30b9\u30b3\u30a2: <strong style="font-size:18px;">${result.compositeScore.toFixed(1)}</strong> / 100
+          </p>
+          <p class="meta" style="margin-bottom:8px;">
+            \u4fe1\u983c\u5ea6: <span class="badge badge-${result.confidence.level}">${confidenceLabel(result.confidence.level)}</span>
+          </p>
+        </div>
+      </div>
 
-      <div class="narrative" style="margin-top:12px;">
-        <h3>評価コメント</h3>
+      ${categoryCards}
+
+      <div class="narrative" style="margin-top:16px;">
+        <h3>\u8a55\u4fa1\u30b3\u30e1\u30f3\u30c8</h3>
         <p>${escapeHtml(generateCityNarrative(result, model.definition, model.totalCities))}</p>
       </div>
 
-      <h3 style="margin-top:12px;">注意事項</h3>
+      <h3 style="margin-top:16px;">\u6ce8\u610f\u4e8b\u9805</h3>
       <ul class="note" style="padding-left:16px;">
         ${notesList}
       </ul>

--- a/src/report/templates/cover.ts
+++ b/src/report/templates/cover.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from "../../utils";
+import { renderCityscapeSvg } from "./charts/cityscape";
 
 export interface CoverModel {
   readonly title: string;
@@ -20,34 +21,83 @@ function numberFormat(value: number): string {
 }
 
 export function renderCover(model: CoverModel): string {
-  const citiesList = model.cities.map((c) => escapeHtml(c)).join("、");
+  const citiesList = model.cities.map((c) => escapeHtml(c)).join("\u3001");
   const dataSources = [`e-Stat API (${escapeHtml(model.statsDataId)})`];
   if (model.hasPriceData) {
-    dataSources.push("不動産情報ライブラリ API");
+    dataSources.push("\u4e0d\u52d5\u7523\u60c5\u5831\u30e9\u30a4\u30d6\u30e9\u30ea API");
   }
 
   const priceConditions: string[] = [];
   if (model.propertyTypeLabel) {
-    priceConditions.push(`物件タイプ: ${escapeHtml(model.propertyTypeLabel)}`);
+    priceConditions.push(
+      `\u7269\u4ef6\u30bf\u30a4\u30d7: ${escapeHtml(model.propertyTypeLabel)}`,
+    );
   }
   if (model.budgetLimit !== undefined) {
-    priceConditions.push(`予算上限: ${numberFormat(model.budgetLimit)}万円`);
+    priceConditions.push(
+      `\u4e88\u7b97\u4e0a\u9650: ${numberFormat(model.budgetLimit)}\u4e07\u5186`,
+    );
   }
+
   const priceConditionLine =
     priceConditions.length > 0
-      ? `${priceConditions.join(" / ")}<br>`
+      ? `<div style="display:flex;align-items:center;gap:8px;"><span style="font-size:16px;">\ud83d\udcb0</span><span>${priceConditions.join(" / ")}</span></div>`
       : "";
 
+  const cityBadges = model.cities
+    .map(
+      (c) =>
+        `<span style="display:inline-block;background:#e0f2fe;color:#075985;padding:4px 14px;border-radius:16px;font-weight:600;font-size:14px;">${escapeHtml(c)}</span>`,
+    )
+    .join(" ");
+
   return `
-    <section class="page" style="display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;">
-      <h1 style="font-size:28px;margin-bottom:24px;">${escapeHtml(model.title)}</h1>
-      <div class="meta" style="line-height:2.2;">
-        生成日時: ${escapeHtml(model.generatedAt)}<br>
-        対象市区町村: ${citiesList}<br>
-        プリセット: ${escapeHtml(model.presetLabel)}<br>
-        ${priceConditionLine}
-        データソース: ${dataSources.join(" / ")}<br>
-        時点: ${escapeHtml(model.timeLabel)}
+    <section class="page" style="display:flex;flex-direction:column;justify-content:center;align-items:center;">
+      <div style="width:100%;border-radius:16px;overflow:hidden;margin-bottom:28px;">
+        ${renderCityscapeSvg()}
+      </div>
+
+      <h1 style="font-size:36px;font-weight:800;color:#1e293b;margin-bottom:8px;text-align:center;">${escapeHtml(model.title)}</h1>
+      <p style="font-size:16px;color:#64748b;margin-bottom:28px;text-align:center;">\u5b50\u80b2\u3066\u4e16\u5e2f\u306e\u305f\u3081\u306e\u8857\u3048\u3089\u3073\u30ec\u30dd\u30fc\u30c8</p>
+
+      <div class="score-card" style="width:100%;max-width:420px;text-align:left;">
+        <div style="display:flex;flex-direction:column;gap:12px;">
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span style="font-size:16px;">\ud83c\udfe2</span>
+            <span style="font-weight:600;color:#1e293b;">\u5bfe\u8c61\u5e02\u533a\u753a\u6751</span>
+          </div>
+          <div style="display:flex;gap:8px;flex-wrap:wrap;padding-left:28px;">${cityBadges}</div>
+
+          <div style="display:flex;align-items:center;gap:8px;margin-top:4px;">
+            <span style="font-size:16px;">\ud83d\udcca</span>
+            <span>\u30d7\u30ea\u30bb\u30c3\u30c8: <strong>${escapeHtml(model.presetLabel)}</strong></span>
+          </div>
+
+          ${priceConditionLine}
+
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span style="font-size:16px;">\ud83d\udcc5</span>
+            <span>\u751f\u6210\u65e5\u6642: ${escapeHtml(model.generatedAt)}</span>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span style="font-size:16px;">\ud83d\udcc1</span>
+            <span>\u30c7\u30fc\u30bf\u30bd\u30fc\u30b9: ${dataSources.join(" / ")}</span>
+          </div>
+
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span style="font-size:16px;">\ud83d\udd52</span>
+            <span>\u6642\u70b9: ${escapeHtml(model.timeLabel)}</span>
+          </div>
+        </div>
+      </div>
+
+      <div style="margin-top:24px;display:flex;justify-content:center;gap:10px;flex-wrap:wrap;">
+        <span class="category-badge" style="background:#d1fae5;color:#065f46;border:1px solid #10b98133;">\ud83d\udc76 \u5b50\u80b2\u3066</span>
+        <span class="category-badge" style="background:#e0f2fe;color:#075985;border:1px solid #0ea5e933;">\ud83c\udfe0 \u4f4f\u5b85\u4fa1\u683c</span>
+        <span class="category-badge" style="background:#ffe4e6;color:#9f1239;border:1px solid #f43f5e33;">\ud83d\udee1\ufe0f \u5b89\u5168</span>
+        <span class="category-badge" style="background:#ede9fe;color:#5b21b6;border:1px solid #8b5cf633;">\ud83c\udf0a \u707d\u5bb3</span>
+        <span class="category-badge" style="background:#fef3c7;color:#92400e;border:1px solid #f59e0b33;">\ud83d\ude83 \u4ea4\u901a</span>
       </div>
     </section>`;
 }

--- a/src/report/templates/dashboard.ts
+++ b/src/report/templates/dashboard.ts
@@ -1,71 +1,115 @@
-import { CityScoreResult, IndicatorDefinition } from "../../scoring/types";
+import {
+  CityScoreResult,
+  IndicatorCategory,
+  IndicatorDefinition,
+} from "../../scoring/types";
 import { escapeHtml } from "../../utils";
+import { renderHorizontalBarChart, BarChartItem } from "./charts/bar";
+import { CATEGORY_COLORS, getCityColor } from "./charts/colors";
 
 export interface DashboardModel {
   readonly results: ReadonlyArray<CityScoreResult>;
   readonly definitions: ReadonlyArray<IndicatorDefinition>;
 }
 
+/** 指標をカテゴリ別にグループ化 */
+function groupByCategory(
+  definitions: ReadonlyArray<IndicatorDefinition>,
+): ReadonlyArray<{
+  readonly category: IndicatorCategory;
+  readonly defs: ReadonlyArray<IndicatorDefinition>;
+}> {
+  const seen = new Set<IndicatorCategory>();
+  const groups: Array<{
+    readonly category: IndicatorCategory;
+    readonly defs: ReadonlyArray<IndicatorDefinition>;
+  }> = [];
+
+  for (const def of definitions) {
+    if (!seen.has(def.category)) {
+      seen.add(def.category);
+      groups.push({
+        category: def.category,
+        defs: definitions.filter((d) => d.category === def.category),
+      });
+    }
+  }
+  return groups;
+}
+
+/** 指標ごとのバーチャートアイテムを構築 */
+function buildBarItems(
+  def: IndicatorDefinition,
+  results: ReadonlyArray<CityScoreResult>,
+): ReadonlyArray<BarChartItem> {
+  return results.map((r, i) => {
+    const cs = r.choice.find((c) => c.indicatorId === def.id);
+    return {
+      label: r.cityName,
+      value: cs?.score ?? 0,
+      color: getCityColor(i),
+    };
+  });
+}
+
 export function renderDashboard(model: DashboardModel): string {
-  const cityNames = model.results.map((r) => r.cityName);
+  const groups = groupByCategory(model.definitions);
 
-  // 指標ヘッダ
-  const headerCells = cityNames
-    .map((name) => `<th>${escapeHtml(name)}</th>`)
-    .join("");
+  const sections = groups
+    .map((group) => {
+      const catColor = CATEGORY_COLORS[group.category];
 
-  // 指標ごとに行を生成（Choice Score）
-  const choiceRows = model.definitions
-    .map((def) => {
-      const cells = model.results
-        .map((r) => {
-          const cs = r.choice.find((c) => c.indicatorId === def.id);
-          if (!cs) {
-            return `<td class="num" style="color:var(--sub)">-</td>`;
-          }
-          return `<td class="num">
-            ${cs.score.toFixed(1)}
-            <div class="score-bar" style="margin-top:2px"><div class="score-bar-fill" style="width:${cs.score}%"></div></div>
-          </td>`;
+      const indicatorCharts = group.defs
+        .map((def) => {
+          const barItems = buildBarItems(def, model.results);
+          const barSvg = renderHorizontalBarChart(barItems, {
+            width: 500,
+            barHeight: 24,
+            gap: 8,
+            labelWidth: 90,
+          });
+
+          // パーセンタイル情報
+          const percentileInfo = model.results
+            .map((r) => {
+              const bs = r.baseline.find((b) => b.indicatorId === def.id);
+              return bs
+                ? `${escapeHtml(r.cityName)}: ${bs.percentile.toFixed(1)}%`
+                : null;
+            })
+            .filter(Boolean)
+            .join(" / ");
+
+          return `
+            <div class="indicator-card" style="border-left:3px solid ${catColor.primary};">
+              <div style="display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px;">
+                <strong style="font-size:14px;">${escapeHtml(def.label)}</strong>
+                <span class="note">${escapeHtml(def.unit)}</span>
+              </div>
+              ${barSvg}
+              ${percentileInfo ? `<div class="note" style="margin-top:4px;">\u30d1\u30fc\u30bb\u30f3\u30bf\u30a4\u30eb: ${percentileInfo}</div>` : ""}
+            </div>`;
         })
-        .join("");
+        .join("\n");
 
-      return `<tr><td><strong>${escapeHtml(def.label)}</strong><br><span class="note">${escapeHtml(def.unit)}</span></td>${cells}</tr>`;
-    })
-    .join("\n");
-
-  // Baseline パーセンタイル
-  const baselineRows = model.definitions
-    .map((def) => {
-      const cells = model.results
-        .map((r) => {
-          const bs = r.baseline.find((b) => b.indicatorId === def.id);
-          if (!bs) {
-            return `<td class="num" style="color:var(--sub)">-</td>`;
-          }
-          return `<td class="num">${bs.percentile.toFixed(1)}%</td>`;
-        })
-        .join("");
-
-      return `<tr><td>${escapeHtml(def.label)}</td>${cells}</tr>`;
+      return `
+        <div class="category-section">
+          <div class="category-header" style="background:${catColor.light};color:${catColor.dark};">
+            <span style="font-size:20px;">${catColor.emoji}</span>
+            ${escapeHtml(catColor.label)}
+          </div>
+          ${indicatorCharts}
+        </div>`;
     })
     .join("\n");
 
   return `
     <section class="page">
-      <h2>指標ダッシュボード</h2>
-
-      <h3>候補内比較スコア（Choice Score: 0-100）</h3>
-      <table>
-        <thead><tr><th>指標</th>${headerCells}</tr></thead>
-        <tbody>${choiceRows}</tbody>
-      </table>
-
-      <h3 style="margin-top:16px;">候補内パーセンタイル（Baseline Score）</h3>
-      <p class="note" style="margin-bottom:8px;">※ Phase 0 では候補セット内での相対パーセンタイルです。</p>
-      <table>
-        <thead><tr><th>指標</th>${headerCells}</tr></thead>
-        <tbody>${baselineRows}</tbody>
-      </table>
+      <h2>\u6307\u6a19\u30c0\u30c3\u30b7\u30e5\u30dc\u30fc\u30c9</h2>
+      <p class="meta">\u5019\u88dc\u5185\u6bd4\u8f03\u30b9\u30b3\u30a2\uff08Choice Score: 0-100\uff09\u306b\u3088\u308b\u6307\u6a19\u5225\u306e\u90fd\u5e02\u6bd4\u8f03</p>
+      ${sections}
+      <div class="note" style="margin-top:12px;">
+        \u203b \u5019\u88dc\u30bb\u30c3\u30c8\u5185\u3067\u306e\u76f8\u5bfe\u30d1\u30fc\u30bb\u30f3\u30bf\u30a4\u30eb\u3067\u3059\u3002
+      </div>
     </section>`;
 }

--- a/src/report/templates/styles.ts
+++ b/src/report/templates/styles.ts
@@ -1,15 +1,27 @@
-/** 共通CSS変数とスタイル定義 */
+/** 共通CSS変数とスタイル定義（子育て世帯向けカラフルデザイン） */
 export function baseStyles(): string {
   return `
     :root {
       --bg: #f8fafc;
       --card: #ffffff;
-      --text: #0f172a;
-      --sub: #334155;
-      --line: #cbd5e1;
-      --head: #e2e8f0;
-      --accent: #1e3a8a;
-      --accent-light: #dbeafe;
+      --text: #1e293b;
+      --sub: #64748b;
+      --line: #e2e8f0;
+      --head: #f1f5f9;
+      --accent: #10b981;
+      --accent-light: #d1fae5;
+
+      --cat-childcare: #10b981;
+      --cat-childcare-light: #d1fae5;
+      --cat-price: #0ea5e9;
+      --cat-price-light: #e0f2fe;
+      --cat-safety: #f43f5e;
+      --cat-safety-light: #ffe4e6;
+      --cat-disaster: #8b5cf6;
+      --cat-disaster-light: #ede9fe;
+      --cat-transport: #f59e0b;
+      --cat-transport-light: #fef3c7;
+
       --success: #16a34a;
       --warning: #d97706;
       --danger: #dc2626;
@@ -17,78 +29,137 @@ export function baseStyles(): string {
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       color: var(--text);
-      background: #ffffff;
+      background: var(--bg);
       font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
-      font-size: 12px;
-      line-height: 1.6;
+      font-size: 13px;
+      line-height: 1.7;
     }
     .page {
-      padding: 24px 28px;
+      padding: 28px 28px;
       page-break-after: always;
-      min-height: calc(100vh - 48px);
+      min-height: calc(100vh - 56px);
     }
     .page:last-child {
       page-break-after: auto;
     }
-    h1 { font-size: 24px; color: var(--accent); margin-bottom: 16px; }
-    h2 { font-size: 18px; color: var(--accent); margin-bottom: 12px; }
-    h3 { font-size: 14px; color: var(--text); margin-bottom: 8px; }
+    h1 { font-size: 36px; font-weight: 800; color: var(--text); margin-bottom: 20px; letter-spacing: -0.02em; }
+    h2 { font-size: 24px; font-weight: 700; color: var(--text); margin-bottom: 16px; letter-spacing: -0.01em; }
+    h3 { font-size: 16px; font-weight: 600; color: var(--text); margin-bottom: 10px; }
     table {
       width: 100%;
-      border-collapse: collapse;
-      font-size: 11px;
-      margin-bottom: 12px;
+      border-collapse: separate;
+      border-spacing: 0;
+      font-size: 12px;
+      margin-bottom: 16px;
+      border-radius: 8px;
+      overflow: hidden;
+      border: 1px solid var(--line);
     }
     th {
       background: var(--head);
-      border: 1px solid var(--line);
-      padding: 6px 8px;
+      padding: 8px 10px;
       text-align: left;
-      font-size: 10px;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--sub);
+      border-bottom: 1px solid var(--line);
     }
     td {
-      border: 1px solid var(--line);
-      padding: 6px 8px;
+      padding: 8px 10px;
+      border-bottom: 1px solid var(--line);
     }
+    tr:last-child td { border-bottom: none; }
     td.num { text-align: right; font-variant-numeric: tabular-nums; }
     .badge {
       display: inline-block;
-      padding: 2px 8px;
-      border-radius: 4px;
-      font-size: 10px;
-      font-weight: bold;
+      padding: 3px 10px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 600;
     }
     .badge-high { background: #dcfce7; color: #166534; }
     .badge-medium { background: #fef3c7; color: #92400e; }
     .badge-low { background: #fee2e2; color: #991b1b; }
+    .category-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px 12px;
+      border-radius: 16px;
+      font-size: 12px;
+      font-weight: 600;
+    }
+    .score-card {
+      background: var(--card);
+      border-radius: 12px;
+      padding: 16px 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+      margin-bottom: 12px;
+    }
+    .ranking-card {
+      background: var(--card);
+      border-radius: 12px;
+      padding: 16px 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+    }
+    .chart-container {
+      display: flex;
+      justify-content: center;
+      margin: 16px 0;
+    }
     .score-bar {
-      height: 8px;
-      border-radius: 4px;
-      background: var(--accent-light);
+      height: 10px;
+      border-radius: 5px;
+      background: var(--line);
     }
     .score-bar-fill {
       height: 100%;
-      border-radius: 4px;
+      border-radius: 5px;
       background: var(--accent);
+      transition: width 0.3s;
     }
-    .meta { color: var(--sub); font-size: 11px; margin-bottom: 12px; }
-    .note { color: var(--sub); font-size: 10px; line-height: 1.5; }
+    .meta { color: var(--sub); font-size: 13px; margin-bottom: 16px; line-height: 1.8; }
+    .note { color: var(--sub); font-size: 11px; line-height: 1.6; }
     .narrative {
       background: var(--accent-light);
-      border-left: 3px solid var(--accent);
-      padding: 12px 16px;
-      margin: 12px 0;
-      border-radius: 0 4px 4px 0;
+      border-left: 4px solid var(--accent);
+      padding: 16px 20px;
+      margin: 16px 0;
+      border-radius: 0 12px 12px 0;
     }
     .narrative h3 {
-      font-size: 12px;
+      font-size: 14px;
       color: var(--accent);
-      margin-bottom: 6px;
+      margin-bottom: 8px;
     }
     .narrative p {
-      font-size: 11px;
+      font-size: 13px;
       line-height: 1.8;
       color: var(--text);
+    }
+    .category-section {
+      margin-bottom: 20px;
+      page-break-inside: avoid;
+    }
+    .category-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 16px;
+      border-radius: 10px;
+      margin-bottom: 12px;
+      font-weight: 700;
+      font-size: 15px;
+    }
+    .indicator-card {
+      background: var(--card);
+      border-radius: 10px;
+      padding: 14px 18px;
+      margin-bottom: 10px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+    }
+    svg text {
+      font-family: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
     }
   `;
 }

--- a/src/report/templates/summary.ts
+++ b/src/report/templates/summary.ts
@@ -1,6 +1,13 @@
-import { CityScoreResult, ConfidenceLevel, IndicatorDefinition } from "../../scoring/types";
+import {
+  CityScoreResult,
+  ConfidenceLevel,
+  IndicatorCategory,
+  IndicatorDefinition,
+} from "../../scoring/types";
 import { escapeHtml } from "../../utils";
 import { generateComparisonNarrative } from "../narrative";
+import { renderRadarChart, RadarChartData } from "./charts/radar";
+import { CATEGORY_COLORS, getCityColor } from "./charts/colors";
 
 export interface SummaryModel {
   readonly results: ReadonlyArray<CityScoreResult>;
@@ -17,54 +24,117 @@ function confidenceBadge(level: ConfidenceLevel): string {
   return `<span class="badge badge-${level}">${labels[level]}</span>`;
 }
 
+function rankMedal(rank: number): string {
+  if (rank === 1) return `<span style="font-size:24px;">\ud83e\udd47</span>`;
+  if (rank === 2) return `<span style="font-size:24px;">\ud83e\udd48</span>`;
+  if (rank === 3) return `<span style="font-size:24px;">\ud83e\udd49</span>`;
+  return `<span style="font-size:20px;font-weight:700;color:#64748b;">${rank}\u4f4d</span>`;
+}
+
+/** カテゴリ別平均スコアを算出 */
+function computeCategoryAverages(
+  result: CityScoreResult,
+  definitions: ReadonlyArray<IndicatorDefinition>,
+): ReadonlyArray<{
+  readonly category: IndicatorCategory;
+  readonly avgScore: number;
+}> {
+  const categories = [
+    ...new Set(definitions.map((d) => d.category)),
+  ] as IndicatorCategory[];
+  return categories.map((cat) => {
+    const catDefs = definitions.filter((d) => d.category === cat);
+    const scores = catDefs
+      .map((d) => result.choice.find((c) => c.indicatorId === d.id)?.score)
+      .filter((s): s is number => s !== undefined);
+    const avg =
+      scores.length > 0
+        ? scores.reduce((a, b) => a + b, 0) / scores.length
+        : 0;
+    return { category: cat, avgScore: avg };
+  });
+}
+
+/** レーダーチャート用データを構築 */
+function buildRadarData(
+  results: ReadonlyArray<CityScoreResult>,
+  definitions: ReadonlyArray<IndicatorDefinition>,
+): RadarChartData {
+  const categories = [
+    ...new Set(definitions.map((d) => d.category)),
+  ] as IndicatorCategory[];
+
+  return {
+    labels: categories.map((cat) => CATEGORY_COLORS[cat].label),
+    datasets: results.map((r, i) => {
+      const avgs = computeCategoryAverages(r, definitions);
+      return {
+        name: r.cityName,
+        values: categories.map(
+          (cat) => avgs.find((a) => a.category === cat)?.avgScore ?? 0,
+        ),
+        color: getCityColor(i),
+      };
+    }),
+    categoryColors: categories.map((cat) => CATEGORY_COLORS[cat].primary),
+  };
+}
+
 export function renderSummary(model: SummaryModel): string {
   const sorted = [...model.results].sort((a, b) => a.rank - b.rank);
 
-  const rankingRows = sorted
-    .map(
-      (r) => `
-      <tr>
-        <td class="num" style="width:8%">${r.rank}</td>
-        <td style="width:25%">${escapeHtml(r.cityName)}</td>
-        <td class="num" style="width:15%">${r.compositeScore.toFixed(1)}</td>
-        <td style="width:22%">
-          <div class="score-bar"><div class="score-bar-fill" style="width:${r.compositeScore}%"></div></div>
-        </td>
-        <td style="width:15%">${confidenceBadge(r.confidence.level)}</td>
-        <td style="width:15%" class="note">${r.notes.length > 0 ? escapeHtml(r.notes[0]) : "-"}</td>
-      </tr>`
-    )
+  // レーダーチャート（3カテゴリ以上で表示）
+  const radarData = buildRadarData(model.results, model.definitions);
+  const radarSvg = renderRadarChart(radarData, { size: 340, showLegend: true });
+
+  // ランキングカード
+  const rankingCards = sorted
+    .map((r) => {
+      const cityIdx = model.results.findIndex(
+        (res) => res.areaCode === r.areaCode,
+      );
+      const cityColor = getCityColor(cityIdx);
+      const scoreColor =
+        r.compositeScore >= 70
+          ? "#10b981"
+          : r.compositeScore >= 40
+            ? "#f59e0b"
+            : "#f43f5e";
+
+      return `
+        <div class="ranking-card" style="border-left:5px solid ${cityColor};flex:1;min-width:140px;">
+          <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px;">
+            ${rankMedal(r.rank)}
+            <span style="font-size:16px;font-weight:700;color:#1e293b;">${escapeHtml(r.cityName)}</span>
+          </div>
+          <div style="font-size:32px;font-weight:800;color:${scoreColor};line-height:1.1;">${r.compositeScore.toFixed(1)}</div>
+          <div style="font-size:11px;color:#64748b;margin:4px 0 8px 0;">\u7dcf\u5408\u30b9\u30b3\u30a2</div>
+          ${confidenceBadge(r.confidence.level)}
+          ${r.notes.length > 0 ? `<div class="note" style="margin-top:6px;">${escapeHtml(r.notes[0])}</div>` : ""}
+        </div>`;
+    })
     .join("\n");
 
   return `
     <section class="page">
-      <h2>結論サマリ</h2>
-      <p class="meta">プリセット: ${escapeHtml(model.presetLabel)} / 候補内比較スコアに基づくランキング</p>
+      <h2>\u7d50\u8ad6\u30b5\u30de\u30ea</h2>
+      <p class="meta">\u30d7\u30ea\u30bb\u30c3\u30c8: ${escapeHtml(model.presetLabel)} / \u5019\u88dc\u5185\u6bd4\u8f03\u30b9\u30b3\u30a2\u306b\u57fa\u3065\u304f\u30e9\u30f3\u30ad\u30f3\u30b0</p>
 
-      <table>
-        <thead>
-          <tr>
-            <th>順位</th>
-            <th>市区町村</th>
-            <th>総合スコア</th>
-            <th>スコア分布</th>
-            <th>信頼度</th>
-            <th>注意</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${rankingRows}
-        </tbody>
-      </table>
+      <div style="display:flex;gap:24px;align-items:flex-start;flex-wrap:wrap;">
+        ${radarSvg ? `<div class="chart-container" style="flex-shrink:0;">${radarSvg}</div>` : ""}
+        <div style="display:flex;flex-direction:column;gap:12px;flex:1;min-width:200px;">
+          ${rankingCards}
+        </div>
+      </div>
 
-      <div class="narrative" style="margin-top:12px;">
-        <h3>総合評価</h3>
+      <div class="narrative" style="margin-top:16px;">
+        <h3>\u7dcf\u5408\u8a55\u4fa1</h3>
         <p>${escapeHtml(generateComparisonNarrative(model.results, model.definitions))}</p>
       </div>
 
       <div class="note" style="margin-top:12px;">
-        ※ 総合スコアは候補内での相対比較値（0-100）です。全国基準ではありません。<br>
-        ※ 信頼度はデータの鮮度・欠損率に基づく参考値です。
+        \u203b \u7dcf\u5408\u30b9\u30b3\u30a2\u306f\u5019\u88dc\u5185\u3067\u306e\u76f8\u5bfe\u6bd4\u8f03\u5024\uff080-100\uff09\u3067\u3059\u3002\u5168\u56fd\u57fa\u6e96\u3067\u306f\u3042\u308a\u307e\u305b\u3093\u3002<br>
+        \u203b \u4fe1\u983c\u5ea6\u306f\u30c7\u30fc\u30bf\u306e\u9bae\u5ea6\u30fb\u6b20\u640d\u7387\u306b\u57fa\u3065\u304f\u53c2\u8003\u5024\u3067\u3059\u3002
       </div>
     </section>`;
 }

--- a/tests/report/charts/bar.test.ts
+++ b/tests/report/charts/bar.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { renderHorizontalBarChart, BarChartItem } from "../../../src/report/templates/charts/bar";
+
+const sampleItems: ReadonlyArray<BarChartItem> = [
+  { label: "世田谷区", value: 85.0, color: "#0ea5e9" },
+  { label: "渋谷区", value: 60.5, color: "#f43f5e" },
+  { label: "新宿区", value: 45.2, color: "#10b981" },
+];
+
+describe("renderHorizontalBarChart", () => {
+  it("SVG文字列を生成する", () => {
+    const svg = renderHorizontalBarChart(sampleItems);
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+  });
+
+  it("各都市のラベルが含まれる", () => {
+    const svg = renderHorizontalBarChart(sampleItems);
+    expect(svg).toContain("世田谷区");
+    expect(svg).toContain("渋谷区");
+    expect(svg).toContain("新宿区");
+  });
+
+  it("スコア値が含まれる", () => {
+    const svg = renderHorizontalBarChart(sampleItems);
+    expect(svg).toContain("85.0");
+    expect(svg).toContain("60.5");
+  });
+
+  it("空配列では空文字を返す", () => {
+    expect(renderHorizontalBarChart([])).toBe("");
+  });
+
+  it("showValues=falseでスコア非表示", () => {
+    const svg = renderHorizontalBarChart(sampleItems, { showValues: false });
+    // バーのrectは存在するがスコアテキストは最小限
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("世田谷区");
+  });
+});

--- a/tests/report/charts/colors.test.ts
+++ b/tests/report/charts/colors.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import {
+  CATEGORY_COLORS,
+  CITY_COLORS,
+  getCategoryColor,
+  getCategoryForIndicator,
+  getCityColor,
+  renderCategoryBadge,
+  renderCategoryLegend,
+} from "../../../src/report/templates/charts/colors";
+import { IndicatorDefinition } from "../../../src/scoring/types";
+
+const definitions: ReadonlyArray<IndicatorDefinition> = [
+  { id: "population_total", label: "総人口", unit: "人", direction: "higher_better", category: "childcare", precision: 0 },
+  { id: "condo_price_median", label: "中古マンション価格", unit: "万円", direction: "lower_better", category: "price", precision: 0 },
+];
+
+describe("CATEGORY_COLORS", () => {
+  it("5カテゴリ全てが定義されている", () => {
+    expect(Object.keys(CATEGORY_COLORS)).toEqual(
+      expect.arrayContaining(["childcare", "price", "safety", "disaster", "transport"]),
+    );
+  });
+
+  it("各カテゴリにprimary/light/dark/emoji/labelが含まれる", () => {
+    for (const color of Object.values(CATEGORY_COLORS)) {
+      expect(color.primary).toMatch(/^#[0-9a-f]{6}$/);
+      expect(color.light).toMatch(/^#[0-9a-f]{6}$/);
+      expect(color.dark).toMatch(/^#[0-9a-f]{6}$/);
+      expect(color.emoji).toBeTruthy();
+      expect(color.label).toBeTruthy();
+    }
+  });
+});
+
+describe("CITY_COLORS", () => {
+  it("7色以上が定義されている", () => {
+    expect(CITY_COLORS.length).toBeGreaterThanOrEqual(7);
+  });
+});
+
+describe("getCategoryColor", () => {
+  it("指定カテゴリのカラーを返す", () => {
+    const color = getCategoryColor("childcare");
+    expect(color.primary).toBe("#10b981");
+    expect(color.label).toBe("子育て");
+  });
+});
+
+describe("getCategoryForIndicator", () => {
+  it("指標IDからカテゴリを解決する", () => {
+    expect(getCategoryForIndicator("population_total", definitions)).toBe("childcare");
+    expect(getCategoryForIndicator("condo_price_median", definitions)).toBe("price");
+  });
+
+  it("存在しない指標IDはundefinedを返す", () => {
+    expect(getCategoryForIndicator("nonexistent", definitions)).toBeUndefined();
+  });
+});
+
+describe("getCityColor", () => {
+  it("インデックスに対応する色を返す", () => {
+    expect(getCityColor(0)).toBe(CITY_COLORS[0]);
+    expect(getCityColor(1)).toBe(CITY_COLORS[1]);
+  });
+
+  it("配列長を超えるインデックスはループする", () => {
+    expect(getCityColor(CITY_COLORS.length)).toBe(CITY_COLORS[0]);
+  });
+});
+
+describe("renderCategoryBadge", () => {
+  it("カテゴリバッジHTMLを生成する", () => {
+    const html = renderCategoryBadge("childcare");
+    expect(html).toContain("category-badge");
+    expect(html).toContain("#10b981");
+    expect(html).toContain("子育て");
+  });
+});
+
+describe("renderCategoryLegend", () => {
+  it("複数カテゴリの凡例を横並びで生成する", () => {
+    const html = renderCategoryLegend(["childcare", "price"]);
+    expect(html).toContain("子育て");
+    expect(html).toContain("住宅価格");
+    expect(html).toContain("display:flex");
+  });
+});

--- a/tests/report/charts/gauge.test.ts
+++ b/tests/report/charts/gauge.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { renderScoreGauge } from "../../../src/report/templates/charts/gauge";
+
+describe("renderScoreGauge", () => {
+  it("SVG文字列を生成する", () => {
+    const svg = renderScoreGauge({ score: 75.5 });
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+  });
+
+  it("スコア数値がテキストとして含まれる", () => {
+    const svg = renderScoreGauge({ score: 78.5 });
+    expect(svg).toContain("78.5");
+  });
+
+  it("ラベルが含まれる", () => {
+    const svg = renderScoreGauge({ score: 60, label: "総合スコア" });
+    expect(svg).toContain("総合スコア");
+  });
+
+  it("順位情報が含まれる", () => {
+    const svg = renderScoreGauge({ score: 80, rank: 1, totalCities: 3 });
+    expect(svg).toContain("1位");
+    expect(svg).toContain("3市区町村");
+  });
+
+  it("スコア0-100の範囲にクランプされる", () => {
+    const svgLow = renderScoreGauge({ score: -10 });
+    expect(svgLow).toContain("0.0");
+    const svgHigh = renderScoreGauge({ score: 150 });
+    expect(svgHigh).toContain("100.0");
+  });
+
+  it("高スコアは緑色になる", () => {
+    const svg = renderScoreGauge({ score: 80 });
+    expect(svg).toContain("#10b981");
+  });
+
+  it("低スコアはローズ色になる", () => {
+    const svg = renderScoreGauge({ score: 20 });
+    expect(svg).toContain("#f43f5e");
+  });
+});

--- a/tests/report/charts/radar.test.ts
+++ b/tests/report/charts/radar.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { renderRadarChart, RadarChartData } from "../../../src/report/templates/charts/radar";
+
+const sampleData: RadarChartData = {
+  labels: ["子育て", "住宅価格", "安全", "災害", "交通"],
+  datasets: [
+    { name: "世田谷区", values: [85, 60, 70, 45, 50], color: "#0ea5e9" },
+    { name: "渋谷区", values: [60, 40, 80, 55, 70], color: "#f43f5e" },
+  ],
+  categoryColors: ["#10b981", "#0ea5e9", "#f43f5e", "#8b5cf6", "#f59e0b"],
+};
+
+describe("renderRadarChart", () => {
+  it("SVG文字列を生成する", () => {
+    const svg = renderRadarChart(sampleData);
+    expect(svg).toContain("<svg");
+    expect(svg).toContain("</svg>");
+  });
+
+  it("データセット数分のpolygonを含む", () => {
+    const svg = renderRadarChart(sampleData);
+    const polygonMatches = svg.match(/<polygon/g);
+    // グリッド(5) + データ(2) = 7
+    expect(polygonMatches).toBeTruthy();
+    expect(polygonMatches!.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("ラベルがSVG内に含まれる", () => {
+    const svg = renderRadarChart(sampleData);
+    expect(svg).toContain("子育て");
+    expect(svg).toContain("住宅価格");
+  });
+
+  it("凡例に都市名が含まれる", () => {
+    const svg = renderRadarChart(sampleData);
+    expect(svg).toContain("世田谷区");
+    expect(svg).toContain("渋谷区");
+  });
+
+  it("3カテゴリ未満では空文字を返す", () => {
+    const data: RadarChartData = {
+      labels: ["A", "B"],
+      datasets: [{ name: "test", values: [50, 50], color: "#000" }],
+    };
+    expect(renderRadarChart(data)).toBe("");
+  });
+
+  it("3カテゴリでSVGを生成できる", () => {
+    const data: RadarChartData = {
+      labels: ["A", "B", "C"],
+      datasets: [{ name: "test", values: [50, 70, 30], color: "#000" }],
+    };
+    const svg = renderRadarChart(data);
+    expect(svg).toContain("<svg");
+  });
+});


### PR DESCRIPTION
## 概要
子育て世帯向けにPDFレポートのデザインを全面刷新しました。従来のデータ羅列型から、カラフルで視覚的にわかりやすいデザインに変更。

## 主な変更
- **カテゴリカラーシステム**: 5カテゴリ（子育て・住宅価格・安全・災害・交通）それぞれに専用色+絵文字
- **SVGチャート**: レーダー・水平バー・半円ゲージを導入（外部ライブラリ不要）
- **タイポグラフィ**: ジャンプ率を2倍→2.8倍に拡大（h1: 36px/800 → body: 13px）
- **ビジュアル**: カバーページに街並みシルエットイラスト、メタ情報カード、カテゴリ凡例バッジ
- **ページ構成**: サマリー（レーダー+ランキングカード）、ダッシュボード（カテゴリ別バーチャート）、都市詳細（ゲージ+カテゴリカード）

## テスト検証
✅ 全436テスト通過（44ファイル）
✅ TypeScriptコンパイル: エラーなし
✅ プレビューPDF: 7ページ正常生成

## ファイル構成
新規: `charts/{colors,radar,bar,gauge,cityscape}.ts` + テスト4ファイル
更新: `styles.ts`, `cover.ts`, `summary.ts`, `dashboard.ts`, `city-detail.ts`

既存テストアサーション全て維持（互換性確保）