### PR TITLE
fix: Supabase Auth サインアップ時のエラーを修正

### DIFF
--- a/packages/web/supabase/migrations/00005_fix_profile_trigger.sql
+++ b/packages/web/supabase/migrations/00005_fix_profile_trigger.sql
@@ -1,0 +1,14 @@
+-- handle_new_user() のセキュリティ修正
+-- search_path を空に設定し、完全修飾テーブル名を使用することで
+-- auth スキーマコンテキストからの実行時にも profiles テーブルを正しく解決する
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email)
+  VALUES (NEW.id, NEW.email);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Supabase Auth のサインアップ時に発生していた「Database error saving new user」エラーを修正しました。

## Changes

- `handle_new_user()` トリガー関数に `SECURITY DEFINER` と `SET search_path = ''` を追加
- テーブル名を完全修飾名（`public.profiles`）に統一
- auth スキーマコンテキストからの実行時にも `profiles` テーブルを確実に解決できるように改善

## Test Plan

1. `/auth/login` からアカウント作成を実行
2. エラーなく新規ユーザーが作成されることを確認
3. `profiles` テーブルにレコードが挿入されることを確認
4. ログイン後、ダッシュボードにアクセスできることを確認