### PR TITLE
feat: Week 3完了 - signoutルート実装

### DIFF
--- a/docs/web/architecture.md
+++ b/docs/web/architecture.md
@@ -926,22 +926,22 @@ STRIPE_PRICE_PREMIUM=
 
 ### Week 3: API + 認証
 
-- [ ] `GET /api/cities/search` 実装
-- [ ] `POST /api/reports` 実装（core パイプライン呼び出し）
-- [ ] `GET /api/reports/[id]` 実装
-- [ ] `GET /api/usage` 実装
-- [ ] Supabase Auth 統合（ログイン/ログアウト/セッション管理）
-- [ ] 認証ミドルウェア実装
-- [ ] Supabase キャッシュアダプタ実装
+- [x] `GET /api/cities/search` 実装
+- [x] `POST /api/reports` 実装（core パイプライン呼び出し）
+- [x] `GET /api/reports/[id]` 実装
+- [x] `GET /api/usage` 実装
+- [x] Supabase Auth 統合（ログイン/ログアウト/セッション管理）
+- [x] 認証ミドルウェア実装
+- [x] Supabase キャッシュアダプタ実装
 
 ### Week 4: フロントエンド - メイン画面
 
-- [ ] トップページ: CitySearch（オートコンプリート）
-- [ ] Recharts コンポーネント: RadarChart, BarChart
-- [ ] ScoreGauge（カスタム SVG）
-- [ ] レポート表示ページ: ScoreSummary, IndicatorDashboard, CityDetail
-- [ ] NarrativeBlock（core の `generateComparisonNarrative` 呼び出し）
-- [ ] Disclaimer
+- [x] トップページ: CitySearch（オートコンプリート）
+- [x] Recharts コンポーネント: RadarChart, BarChart
+- [x] ScoreGauge（カスタム SVG）
+- [x] レポート表示ページ: ScoreSummary, IndicatorDashboard, CityDetail
+- [x] NarrativeBlock（core の `generateComparisonNarrative` 呼び出し）
+- [x] Disclaimer
 
 ### Week 5: 決済 + 利用量管理
 

--- a/packages/web/src/app/auth/signout/route.ts
+++ b/packages/web/src/app/auth/signout/route.ts
@@ -1,0 +1,15 @@
+/**
+ * ログアウト Route Handler。
+ * セッションを破棄してトップページへリダイレクトする。
+ */
+
+import { NextResponse } from "next/server";
+import { createServerSupabaseClient } from "@/lib/supabase/server";
+
+export async function POST(request: Request) {
+  const supabase = await createServerSupabaseClient();
+  await supabase.auth.signOut();
+
+  const { origin } = new URL(request.url);
+  return NextResponse.redirect(`${origin}/`);
+}

--- a/packages/web/tests/app/auth/signout.test.ts
+++ b/packages/web/tests/app/auth/signout.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// vi.hoisted でモック変数を先に宣言（vi.mock ホイスティング対応）
+const { mockSignOut, MockNextResponse } = vi.hoisted(() => {
+  const mockSignOut = vi.fn();
+
+  class MockNextResponse {
+    status: number;
+    headers: Map<string, string>;
+    constructor(url: string, status: number) {
+      this.status = status;
+      this.headers = new Map([["location", url]]);
+    }
+    static redirect(url: string | URL) {
+      return new MockNextResponse(String(url), 302);
+    }
+  }
+
+  return { mockSignOut, MockNextResponse };
+});
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerSupabaseClient: vi.fn().mockResolvedValue({
+    auth: { signOut: mockSignOut },
+  }),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: MockNextResponse,
+}));
+
+import { POST } from "@/app/auth/signout/route";
+
+describe("POST /auth/signout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  it("supabase.auth.signOut() を呼び出す", async () => {
+    const request = new Request("http://localhost:3000/auth/signout", {
+      method: "POST",
+    });
+
+    await POST(request);
+
+    expect(mockSignOut).toHaveBeenCalledOnce();
+  });
+
+  it("signout 後にトップページへリダイレクトする", async () => {
+    const request = new Request("http://localhost:3000/auth/signout", {
+      method: "POST",
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe("http://localhost:3000/");
+  });
+});


### PR DESCRIPTION
## Summary

Week 3「API + 認証」の実装を完全に完了しました。

- **signout Route Handler実装** (`/auth/signout/route.ts`) - Supabase Auth.signOut()を呼び出してセッションを破棄し、トップページへリダイレクト
- **signout テスト追加** - Supabase呼び出し検証とリダイレクト確認の2テスト
- **ドキュメント更新** - 設計書の Week 3・4 チェックリストを全て完了マークに更新

## Verification

✅ テスト: 20ファイル 143テスト全パス（新規 2テスト含む）
✅ ビルド: `npm run build` 成功
✅ 動作確認: `/auth/signout` ルートが正常に認識

## Notes

Week 3 は完全に完了しました。次フェーズに進む準備ができています。

🤖 Generated with [Claude Code](https://claude.ai/code)