### PR TITLE
fix: CommandInputのfont-sizeを16pxにしてiPhoneのズームを防止

### DIFF
--- a/packages/web/src/components/ui/command.tsx
+++ b/packages/web/src/components/ui/command.tsx
@@ -73,7 +73,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}


### PR DESCRIPTION
iOSのSafariではfont-sizeが16px未満のinput要素にフォーカスすると
画面が自動ズームされる。CommandInputのtext-smをtext-base md:text-sm
に変更し、モバイルでは16px（text-base）を適用することで解決。

https://claude.ai/code/session_01DGD89XoeWTWF6GShU1DNoW