### PR TITLE
fix: モバイルでログイン時のヘッダーテキストはみ出しを修正

### DIFF
--- a/packages/web/src/components/layout/header.tsx
+++ b/packages/web/src/components/layout/header.tsx
@@ -10,27 +10,27 @@ export async function Header() {
 
   return (
     <header className="border-b border-border bg-background">
-      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
+      <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-2 sm:px-4">
         <Link href="/" className="text-lg font-bold tracking-tight">
           TownLens
         </Link>
-        <nav className="flex items-center gap-2">
-          <Button variant="ghost" size="sm" asChild>
+        <nav className="flex items-center gap-1 sm:gap-2">
+          <Button variant="ghost" size="sm" asChild className="px-2 text-xs sm:px-3 sm:text-sm">
             <Link href="/pricing">料金プラン</Link>
           </Button>
           {user ? (
             <>
-              <Button variant="ghost" size="sm" asChild>
+              <Button variant="ghost" size="sm" asChild className="px-2 text-xs sm:px-3 sm:text-sm">
                 <Link href="/dashboard">ダッシュボード</Link>
               </Button>
               <form action="/auth/signout" method="post">
-                <Button variant="outline" size="sm" type="submit">
+                <Button variant="outline" size="sm" type="submit" className="px-2 text-xs sm:px-3 sm:text-sm">
                   ログアウト
                 </Button>
               </form>
             </>
           ) : (
-            <Button variant="outline" size="sm" asChild>
+            <Button variant="outline" size="sm" asChild className="px-2 text-xs sm:px-3 sm:text-sm">
               <Link href="/auth/login">ログイン</Link>
             </Button>
           )}


### PR DESCRIPTION
sm breakpoint 未満でコンテナpadding・ボタン間gap・ボタンのfont-size/paddingを
縮小し、375px幅でもナビゲーション要素が収まるようにした。

https://claude.ai/code/session_01GqQyZ2biEdw4GKVNQkd1Ho