### PR TITLE
docs: README.md を全面更新 — モノレポ・Web・3モード対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,87 @@
 # TownLens
 
-政府統計（e-Stat）・不動産情報ライブラリ API・災害データを統合し、市区町村の多角的比較スコアリング・PDFレポートを生成する CLI ツールです。
+政府統計（e-Stat）・不動産情報ライブラリ API・災害データを統合し、市区町村の多角的比較スコアリング・PDFレポートを生成するツールです。CLI と Web アプリの両方を提供します。
+
+## プロジェクト構成
+
+pnpm workspaces + Turborepo によるモノレポ構成です。
+
+```
+packages/
+  core/   — 共通ロジック（APIクライアント・スコアリングエンジン）
+  cli/    — CLIツール（@townlens/cli）
+  web/    — Webアプリ（Next.js 15）
+```
 
 ## セットアップ
 
 ```bash
-npm install
-npx playwright install chromium
-npm run build
-npm link          # townlens コマンドをグローバルに登録
+pnpm install
+```
+
+### CLI
+
+```bash
+pnpm run build
+cd packages/cli && pnpm link --global   # townlens コマンドをグローバルに登録
+npx playwright install chromium          # PDF生成に必要
 ```
 
 ```bash
 townlens init
-# .env または環境変数で ESTAT_APP_ID を設定
-# 不動産価格・災害リスクデータも使う場合は REINFOLIB_API_KEY も設定
+# .env に ESTAT_APP_ID を設定
+# 不動産価格・災害リスクも使う場合は REINFOLIB_API_KEY も設定
 ```
 
 > `townlens init` が生成する `townlens.config.json` にはデフォルトの統計表IDが設定済みです。通常は編集不要です。
 
-## コマンド
+### Web
+
+```bash
+cd packages/web
+cp ../../.env.example .env.local
+# .env.local に Supabase / Stripe の環境変数を設定
+pnpm dev
+```
+
+## 環境変数
+
+`.env.example` を参照してください。
+
+| 変数 | 用途 | 必須 |
+|------|------|------|
+| `ESTAT_APP_ID` | e-Stat API | CLI / Web |
+| `REINFOLIB_API_KEY` | 不動産情報ライブラリ API | 任意 |
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase プロジェクトURL | Web |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase 匿名キー | Web |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase サービスロールキー | Web |
+| `STRIPE_SECRET_KEY` | Stripe シークレットキー | Web |
+| `STRIPE_WEBHOOK_SECRET` | Stripe Webhook シークレット | Web |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe 公開キー | Web |
+| `STRIPE_PRICE_STANDARD` | Standard プラン Price ID | Web |
+| `STRIPE_PRICE_PREMIUM` | Premium プラン Price ID | Web |
+
+## CLI コマンド
 
 ### report — 比較レポート生成
 
+3つのモードで比較レポートをPDF出力します。
+
 ```bash
+# 市区町村モード
 townlens report --cities "新宿区,横浜市,大阪市"
-townlens report --cities "新宿区,横浜市,大阪市" --out ./out/report.pdf
-townlens report --cities "新宿区,横浜市,大阪市" --no-scored  # スコアなし基本レポート
+
+# メッシュモード（1km 3次メッシュ）
+townlens report --mesh "53394525,53394526"
+
+# 駅圏モード
+townlens report --stations "渋谷,新宿" --radius 1000
+
+# インタラクティブモード（ウィザード形式で入力）
+townlens report --interactive
 ```
 
 デフォルトでスコア付きレポート（人口・犯罪統計・不動産価格・災害リスク）を生成します。
-人口データ・犯罪統計のデータセットはビルトインで定義済みのため、`--statsDataId` の指定は不要です。
 不動産価格・災害リスクデータには `REINFOLIB_API_KEY` が必要です（未設定時は警告付きでスキップ）。
 
 ### search — 統計表の検索
@@ -41,39 +92,64 @@ townlens search --keyword "人口"
 
 ### inspect — 統計表の診断
 
-任意の統計表IDが自動検出に対応しているか診断します。
-
 ```bash
 townlens inspect --statsDataId 0003448299
 townlens inspect --statsDataId 0000032962 --json
 ```
 
-`npm link` を使わない場合は `npx` 経由でも実行できます。
+### report の主要オプション
+
+| オプション | 説明 |
+|-----------|------|
+| `--cities <list>` | 市区町村名をカンマ区切りで指定 |
+| `--mesh <codes>` | メッシュコードをカンマ区切りで指定 |
+| `--stations <list>` | 駅名をカンマ区切りで指定 |
+| `--radius <meters>` | 駅圏の半径（デフォルト: 1000m） |
+| `--interactive` | インタラクティブモードで実行 |
+| `--out <path>` | PDF出力先 |
+| `--preset <name>` | 重みプリセット（childcare/price/safety） |
+| `--no-scored` | スコアなし基本レポート |
+| `--no-price` | 不動産価格データなし |
+| `--no-crime` | 犯罪統計データなし |
+| `--no-disaster` | 災害リスクデータなし |
+| `--year <YYYY>` | 不動産取引データの年 |
+| `--quarter <1-4>` | 四半期 |
+| `--property-type <type>` | 物件タイプ（condo/house/land/all） |
+| `--budget-limit <万円>` | 予算上限（万円） |
+
+全オプションの詳細は [packages/cli/README.md](packages/cli/README.md) を参照してください。
+
+## Web アプリ
+
+Next.js 15 / React 19 / Supabase / Stripe / Tailwind CSS 4 による Web アプリです。
+
+- トップページ — 都市検索・レポート生成
+- ダッシュボード — 生成済みレポート一覧
+- レポート表示 — スコア・チャート付き詳細レポート
+- 料金プラン — `/pricing` ページを参照
+
+詳細は [packages/web/README.md](packages/web/README.md) を参照してください。
+
+## 開発
 
 ```bash
-npx townlens report --cities "新宿区,横浜市,大阪市"
+# 全パッケージのビルド
+pnpm run build
 
-# 開発中は tsx で直接実行も可能
-npm run dev -- report --cities "新宿区,横浜市,大阪市"
+# CLI 開発実行
+pnpm run dev -- report --cities "新宿区,渋谷区"
+
+# Web 開発サーバー
+cd packages/web && pnpm dev
+
+# テスト
+pnpm run test
+
+# カバレッジ（80%必須）
+pnpm run test:coverage
 ```
 
-### report オプション
-
-- `--cities "市区町村,市区町村,..."` (必須)
-- `--statsDataId <ID>` (省略時はビルトインデフォルトを使用)
-- `--profile <name>` (`townlens.config.json` の profile)
-- `--out <path>`
-- `--no-scored` (スコアなし基本レポートで生成)
-- `--no-price` (不動産価格データなしで実行)
-- `--no-crime` (犯罪統計データなしで実行)
-- `--no-disaster` (災害リスクデータなしで実行)
-- `--classId <id>` / `--totalCode <code>` / `--kidsCode <code>` (年齢分類を手動指定)
-- `--timeCode <code>` (時間軸を手動指定)
-- `--crimeStatsId <ID>` (犯罪統計の統計表IDを上書き)
-
 ## ビルトインデータセット
-
-以下のデータセットがデフォルトで使用されます。
 
 | データ | 統計表ID | 出典 |
 |--------|----------|------|

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,154 @@
+# @townlens/cli
+
+TownLens のコマンドラインツールです。市区町村・メッシュ・駅圏の比較レポートをPDFで出力します。
+
+## セットアップ
+
+```bash
+pnpm install
+pnpm run build
+pnpm link --global          # townlens コマンドをグローバルに登録
+npx playwright install chromium  # PDF生成に必要
+```
+
+```bash
+townlens init
+# .env に ESTAT_APP_ID を設定
+# 不動産価格・災害リスクも使う場合は REINFOLIB_API_KEY も設定
+```
+
+## コマンド
+
+### report — 比較レポート生成
+
+3つのモードでレポートを生成します。`--cities`、`--mesh`、`--stations` のいずれか1つを指定してください。
+
+#### 市区町村モード
+
+```bash
+townlens report --cities "新宿区,横浜市,大阪市"
+townlens report --cities "新宿区,横浜市" --preset safety --out ./report.pdf
+```
+
+#### メッシュモード
+
+```bash
+townlens report --mesh "53394525,53394526"
+townlens report --mesh "53394525,53394526" --mesh-stats-id <id>
+```
+
+#### 駅圏モード
+
+```bash
+townlens report --stations "渋谷,新宿"
+townlens report --stations "渋谷,新宿" --radius 500
+```
+
+#### インタラクティブモード
+
+```bash
+townlens report --interactive
+```
+
+ウィザード形式でモード選択・対象入力・プリセット選択を対話的に行います。
+
+### search — 統計表の検索
+
+```bash
+townlens search --keyword "人口"
+```
+
+### inspect — 統計表の診断
+
+```bash
+townlens inspect --statsDataId 0003448299
+townlens inspect --statsDataId 0000032962 --json
+```
+
+### init — 設定ファイル生成
+
+```bash
+townlens init
+```
+
+`townlens.config.json` を生成します。デフォルトの統計表IDが設定済みのため、通常は編集不要です。
+
+## report 全オプション
+
+### モード選択（いずれか1つ必須）
+
+| オプション | 説明 |
+|-----------|------|
+| `--cities <list>` | 市区町村名をカンマ区切り |
+| `--mesh <codes>` | メッシュコードをカンマ区切り（8桁=3次メッシュ） |
+| `--stations <list>` | 駅名をカンマ区切り |
+| `--interactive` | インタラクティブモード |
+
+### 出力・表示
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `--out <path>` | PDF出力先 | `./townlens-report.pdf` |
+| `--no-scored` | スコアなし基本レポート | スコアあり |
+| `--preset <name>` | 重みプリセット（childcare/price/safety） | `childcare` |
+
+### 駅圏モード
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `--radius <meters>` | 駅圏の半径（メートル） | `1000` |
+
+### 不動産データ
+
+| オプション | 説明 | デフォルト |
+|-----------|------|-----------|
+| `--no-price` | 不動産価格データなし | 有効 |
+| `--year <YYYY>` | 取引データの年 | 前年 |
+| `--quarter <1-4>` | 四半期 | — |
+| `--property-type <type>` | 物件タイプ（condo/house/land/all） | `condo` |
+| `--budget-limit <万円>` | 予算上限（万円） | — |
+
+### 統計データ
+
+| オプション | 説明 |
+|-----------|------|
+| `--statsDataId <id>` | 統計表ID（省略時はビルトインデフォルト） |
+| `--profile <name>` | profile名（townlens.config.json） |
+| `--no-crime` | 犯罪統計データなし |
+| `--crime-stats-id <id>` | 犯罪統計の統計表IDを上書き |
+| `--no-disaster` | 災害リスクデータなし |
+| `--mesh-stats-id <id>` | メッシュ統計の statsDataId |
+
+### 年齢分類（手動指定）
+
+| オプション | 説明 |
+|-----------|------|
+| `--classId <id>` | 年齢区分の分類ID（例: cat01） |
+| `--totalCode <code>` | 総数の分類コード |
+| `--kidsCode <code>` | 0〜14歳の分類コード |
+| `--timeCode <code>` | 時間コード |
+
+## ソース構成
+
+```
+src/
+  commands/      — CLI コマンド定義（report, search, inspect, init）
+  report/        — HTML テンプレート・PDF 変換
+  interactive/   — インタラクティブモード（fuzzy search・プロンプト）
+  mesh/          — メッシュデータ処理
+  station/       — 駅圏データ・ジオコーディング
+  geo/           — 地理情報リゾルバ
+  cache/         — ファイルベースキャッシュ
+  config/        — 設定ファイル読み込み
+  estat/         — inspect コマンド用ロジック
+```
+
+## 開発コマンド
+
+```bash
+pnpm run dev -- report --cities "新宿区,渋谷区"   # tsx で直接実行
+pnpm run build                                     # TypeScript コンパイル
+pnpm run test                                      # テスト（watch モード）
+pnpm run test:run                                  # テスト（1回実行）
+pnpm run test:coverage                             # カバレッジ測定
+```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,59 @@
+# @townlens/core
+
+CLI・Web で共有するビジネスロジックパッケージです。
+
+## モジュール構成
+
+```
+src/
+  estat/        — e-Stat APIクライアント・メタ情報解析・犯罪統計
+  reinfo/       — 不動産情報ライブラリAPIクライアント・価格統計・災害リスク
+  scoring/      — スコアリングエンジン（正規化・パーセンタイル・重み付き総合・信頼度）
+  pipeline/     — レポート生成パイプライン（データ取得→スコアリングの統合フロー）
+  narrative/    — 自然言語コメント生成
+  charts/       — チャートカラー定義
+  normalize/    — ラベル・カナ正規化
+  config/       — ビルトインデータセット定義
+```
+
+## 主要エクスポート
+
+### スコアリング
+
+- `scoreCities()` — メインのスコアリング関数
+- `normalizeWithinCandidates()` — 候補内 Min-Max 正規化（0〜100）
+- `calculatePercentile()` — パーセンタイルベースのベースラインスコア
+- `calculateCompositeScore()` — 重み付き総合スコア
+- `evaluateConfidence()` — データ信頼度評価
+- `CHILDCARE_FOCUSED` / `PRICE_FOCUSED` / `SAFETY_FOCUSED` — 重みプリセット
+
+### API クライアント
+
+- `EstatApiClient` — e-Stat API クライアント
+- `ReinfoApiClient` — 不動産情報ライブラリ API クライアント
+
+### パイプライン
+
+- `runReportPipeline()` — データ取得→スコアリングを一括実行
+
+### 型定義
+
+- `ReportRow` / `CityIndicators` / `CityScoreResult` — 主要データ型
+- `CacheAdapter` — キャッシュアダプタインターフェース
+
+## 利用方法
+
+`@townlens/cli` と `@townlens/web` から `workspace:*` で参照されています。
+
+```typescript
+import { scoreCities, EstatApiClient } from "@townlens/core";
+```
+
+## 開発コマンド
+
+```bash
+pnpm run build           # TypeScript コンパイル
+pnpm run test            # テスト（Vitest / watch モード）
+pnpm run test:run        # テスト（1回実行）
+pnpm run test:coverage   # カバレッジ測定
+```

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,83 @@
+# @townlens/web
+
+TownLens の Web アプリケーションです。ブラウザから都市比較レポートを生成・閲覧できます。
+
+## 技術スタック
+
+- **Next.js 15**（App Router）
+- **React 19**
+- **Supabase**（認証 + データベース）
+- **Stripe**（決済）
+- **Tailwind CSS 4**
+- **Recharts**（データ可視化）
+- **Radix UI**（UIコンポーネント）
+
+## セットアップ
+
+### 1. 環境変数の設定
+
+```bash
+cp ../../.env.example .env.local
+```
+
+`.env.local` に以下を設定してください。
+
+```bash
+# 必須
+ESTAT_APP_ID=
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Stripe（決済機能を使う場合）
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
+STRIPE_PRICE_STANDARD=
+STRIPE_PRICE_PREMIUM=
+
+# 任意
+REINFOLIB_API_KEY=
+```
+
+### 2. 開発サーバーの起動
+
+```bash
+pnpm dev
+```
+
+`http://localhost:3000` でアクセスできます。
+
+## ページ構成
+
+| パス | 説明 |
+|------|------|
+| `/` | トップページ（都市検索） |
+| `/auth/login` | ログイン |
+| `/dashboard` | ダッシュボード（レポート一覧） |
+| `/pricing` | 料金プラン |
+| `/report/[id]` | レポート表示 |
+
+## API Routes
+
+| エンドポイント | メソッド | 説明 |
+|---------------|---------|------|
+| `/api/reports` | POST | レポート生成 |
+| `/api/reports/[id]` | GET | レポート取得 |
+| `/api/cities/search` | GET | 都市名検索（オートコンプリート） |
+| `/api/usage` | GET | 利用状況の確認 |
+| `/api/stripe/checkout` | POST | Stripe 決済セッション作成 |
+| `/api/stripe/portal` | POST | Stripe カスタマーポータル |
+| `/api/stripe/webhook` | POST | Stripe Webhook 受信 |
+
+## 開発コマンド
+
+```bash
+pnpm dev              # 開発サーバー起動
+pnpm build            # プロダクションビルド
+pnpm start            # プロダクション起動
+pnpm lint             # ESLint
+pnpm test             # テスト（watch モード）
+pnpm test:run         # テスト（1回実行）
+pnpm test:coverage    # カバレッジ測定
+```


### PR DESCRIPTION
## 概要

ルート README.md をモノレポ時代に合わせて全面リライト。プロジェクト全体像、セットアップ手順（pnpm）、CLI の 3 モード（市区町村/メッシュ/駅圏）、Web アプリケーション、環境変数を記載しました。

各パッケージのルートに README.md を新規作成し、パッケージ別の詳細情報を整理。

## 変更内容

- **README.md（ルート）**：モノレポ構成・セットアップ・全コマンド・Web 概要
- **packages/core/README.md**（新規）：モジュール構成・公開 API
- **packages/cli/README.md**（新規）：全コマンド・全オプションのリファレンス
- **packages/web/README.md**（新規）：技術スタック・環境変数・ページ構成・API Routes

## テスト

- `pnpm install && pnpm build` 成功確認