### PR TITLE
fix: robots.txtで/api/ogを許可しXのOGP画像取得を修正

### DIFF
--- a/packages/web/src/app/robots.ts
+++ b/packages/web/src/app/robots.ts
@@ -7,7 +7,7 @@ export default function robots(): MetadataRoute.Robots {
   return {
     rules: {
       userAgent: "*",
-      allow: "/",
+      allow: ["/", "/api/og"],
       disallow: ["/dashboard", "/api/", "/auth/callback"],
     },
     sitemap: `${baseUrl}/sitemap.xml`,


### PR DESCRIPTION
/api/ 全体をdisallowしていたためTwitterbotがOG画像URLを
取得できずXでカード画像が表示されなかった。
/api/og を明示的にallowすることで解決。

https://claude.ai/code/session_01LwyVqqEq5A8Zhc2VtRZqu1